### PR TITLE
[bufferorch] Fix issue: bufferorch only pass the first attribute to sai when setting attributes

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -335,11 +335,14 @@ task_process_status BufferOrch::processBufferPool(Consumer &consumer)
         }
         if (SAI_NULL_OBJECT_ID != sai_object)
         {
-            sai_status = sai_buffer_api->set_buffer_pool_attribute(sai_object, &attribs[0]);
-            if (SAI_STATUS_SUCCESS != sai_status)
+            for (auto &attribute : attribs)
             {
-                SWSS_LOG_ERROR("Failed to modify buffer pool, name:%s, sai object:%" PRIx64 ", status:%d", object_name.c_str(), sai_object, sai_status);
-                return task_process_status::task_failed;
+                sai_status = sai_buffer_api->set_buffer_pool_attribute(sai_object, &attribute);
+                if (SAI_STATUS_SUCCESS != sai_status)
+                {
+                    SWSS_LOG_ERROR("Failed to modify buffer pool, name:%s, sai object:%" PRIx64 ", status:%d", object_name.c_str(), sai_object, sai_status);
+                    return task_process_status::task_failed;
+                }
             }
             SWSS_LOG_DEBUG("Modified existing pool:%" PRIx64 ", type:%s name:%s ", sai_object, map_type_name.c_str(), object_name.c_str());
         }
@@ -504,11 +507,14 @@ task_process_status BufferOrch::processBufferProfile(Consumer &consumer)
         if (SAI_NULL_OBJECT_ID != sai_object)
         {
             SWSS_LOG_DEBUG("Modifying existing sai object:%" PRIx64, sai_object);
-            sai_status = sai_buffer_api->set_buffer_profile_attribute(sai_object, &attribs[0]);
-            if (SAI_STATUS_SUCCESS != sai_status)
+            for (auto &attribute : attribs)
             {
-                SWSS_LOG_ERROR("Failed to modify buffer profile, name:%s, sai object:%" PRIx64 ", status:%d", object_name.c_str(), sai_object, sai_status);
-                return task_process_status::task_failed;
+                sai_status = sai_buffer_api->set_buffer_profile_attribute(sai_object, &attribute);
+                if (SAI_STATUS_SUCCESS != sai_status)
+                {
+                    SWSS_LOG_ERROR("Failed to modify buffer profile, name:%s, sai object:%" PRIx64 ", status:%d", object_name.c_str(), sai_object, sai_status);
+                    return task_process_status::task_failed;
+                }
             }
         }
         else


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fix issue: bufferorch only pass the first attribute to sai when setting attributes

Signed-off-by: Stephen Sun <stephens@nvidia.com>

**Why I did it**

**How I verified it**

**Details if related**
