### PR TITLE
[Dynamic Buffer Calc] Bugfix: A suffix keeps being added if a non-exist buffer pool is referenced.

### DIFF
--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -1472,8 +1472,8 @@ task_process_status BufferMgrDynamic::handleBufferProfileTable(KeyOpFieldsValues
         }
         for (auto i = kfvFieldsValues(tuple).begin(); i != kfvFieldsValues(tuple).end(); i++)
         {
-            string &field = fvField(*i);
-            string &value = fvValue(*i);
+            const string &field = fvField(*i);
+            string value = fvValue(*i);
 
             SWSS_LOG_DEBUG("field:%s, value:%s", field.c_str(), value.c_str());
             if (field == buffer_pool_field_name)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Bug:
The buffermgrd can keep adding suffix to the buffer pool reference if the buffer pool isn't found when it is being referenced. In most of the cases, it's caused by wrong configuration.
Cause:
In handleBufferProfileTable, the value of each field is designated by a (lvalue) reference to the object in the tuple, which means the object in the tuple will be changed if the value is changed in the function.
Fix:
Pass the value of each field by value instead of reference.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

**Why I did it**
Fix bug.

**How I verified it**
Manually test.

**Details if related**
