### PR TITLE
[Dynamic Buffer Calc] Don't update pools when ingress_lossless_pool is created during initialization

### DIFF
--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -946,7 +946,10 @@ void BufferMgrDynamic::refreshSharedHeadroomPool(bool enable_state_updated_by_ra
             updateBufferPoolToDb(INGRESS_LOSSLESS_PG_POOL_NAME, ingressLosslessPool);
     }
 
-    checkSharedBufferPoolSize();
+    if (m_portInitDone)
+    {
+        checkSharedBufferPoolSize();
+    }
 }
 
 // Main flows


### PR DESCRIPTION

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fix bug: Don't update pools when ingress_lossless_pool is created during initialization.
This can cause error logs during system start up.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

**Why I did it**
Fix the bug.

**How I verified it**
Run regression and vs test.

**Details if related**
The buffer pools will be created after a short-timer and then won't be updated until the initialization has finished. This is to avoid repeatedly updating buffer pools when BUFFER_PG and BUFFER_QUEUE have been created for each port.
However, when the ingress_lossless_pool is created it will trigger the buffer pools to be updated for the shared headroom pool. If this happens during initialization, it causes all the buffer pools created after ingress_lossless_pool won't be created until the initialization has been done.
Fix: Don't trigger updating buffer pools when creating ingress_lossless_pool during initialization.

