### PR TITLE
[Dynamic Buffer Calc] Don't create lossy PG for admin down ports during initialization

### DIFF
--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -1862,9 +1862,13 @@ task_process_status BufferMgrDynamic::handleOneBufferPgEntry(const string &key, 
         }
         else
         {
-            SWSS_LOG_NOTICE("Inserting BUFFER_PG table entry %s into APPL_DB directly", key.c_str());
-            m_applBufferPgTable.set(key, fvVector);
-            bufferPg.running_profile_name = bufferPg.configured_profile_name;
+            port_info_t &portInfo = m_portInfoLookup[port];
+            if (PORT_ADMIN_DOWN != portInfo.state)
+            {
+                SWSS_LOG_NOTICE("Inserting BUFFER_PG table entry %s into APPL_DB directly", key.c_str());
+                m_applBufferPgTable.set(key, fvVector);
+                bufferPg.running_profile_name = bufferPg.configured_profile_name;
+            }
         }
 
         if (!bufferPg.configured_profile_name.empty())

--- a/cfgmgr/buffermgrdyn.h
+++ b/cfgmgr/buffermgrdyn.h
@@ -79,12 +79,12 @@ typedef struct {
 } buffer_pg_t;
 
 typedef enum {
+    // Port is admin down. All PGs programmed to APPL_DB should be removed from the port
+    PORT_ADMIN_DOWN,
     // Port is under initializing, which means its info hasn't been comprehensive for calculating headroom
     PORT_INITIALIZING,
     // All necessary information for calculating headroom is ready
-    PORT_READY,
-    // Port is admin down. All PGs programmed to APPL_DB should be removed from the port
-    PORT_ADMIN_DOWN
+    PORT_READY
 } port_state_t;
 
 typedef struct {

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2732,9 +2732,11 @@ void PortsOrch::doPortTask(Consumer &consumer)
                 continue;
             }
 
-            if (!gBufferOrch->isPortReady(alias))
+            if (!gBufferOrch->isPortReady(alias) && (admin_status == "up"))
             {
                 // buffer configuration hasn't been applied yet. save it for future retry
+                // We don't need to check it if the port isn't admin up because
+                // the buffer configuration won't be applied until the port is admin up
                 m_pendingPortSet.emplace(alias);
                 it++;
                 continue;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
- Don't create lossy PG for admin down ports during system initialization
- Always treat admin down ports as ready during orchagent initialization

Signed-off-by: Stephen Sun <stephens@nvidia.com>

**Why I did it**
Lossy PGs for admin down ports should not be applied to APPL_DB.
Originally, we had the logic to remove lossy/lossless PGs when shutting a port. The same logic should be applied when the system is starting.

**How I verified it**

**Details if related**
