### PR TITLE
[BufferOrch] Don't call SAI API for BUFFER_POOL/PROFILE handling in case the op is DEL and the SAI OID is NULL

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -416,14 +416,17 @@ task_process_status BufferOrch::processBufferPool(KeyOpFieldsValuesTuple &tuple)
             return task_process_status::task_need_retry;
         }
 
-        sai_status = sai_buffer_api->remove_buffer_pool(sai_object);
-        if (SAI_STATUS_SUCCESS != sai_status)
+        if (SAI_NULL_OBJECT_ID == sai_object)
         {
-            SWSS_LOG_ERROR("Failed to remove buffer pool %s with type %s, rv:%d", object_name.c_str(), map_type_name.c_str(), sai_status);
-            task_process_status handle_status = handleSaiRemoveStatus(SAI_API_BUFFER, sai_status);
-            if (handle_status != task_process_status::task_success)
+            sai_status = sai_buffer_api->remove_buffer_pool(sai_object);
+            if (SAI_STATUS_SUCCESS != sai_status)
             {
-                return handle_status;
+                SWSS_LOG_ERROR("Failed to remove buffer pool %s with type %s, rv:%d", object_name.c_str(), map_type_name.c_str(), sai_status);
+                task_process_status handle_status = handleSaiRemoveStatus(SAI_API_BUFFER, sai_status);
+                if (handle_status != task_process_status::task_success)
+                {
+                    return handle_status;
+                }
             }
         }
         SWSS_LOG_NOTICE("Removed buffer pool %s with type %s", object_name.c_str(), map_type_name.c_str());
@@ -615,14 +618,17 @@ task_process_status BufferOrch::processBufferProfile(KeyOpFieldsValuesTuple &tup
             return task_process_status::task_need_retry;
         }
 
-        sai_status = sai_buffer_api->remove_buffer_profile(sai_object);
-        if (SAI_STATUS_SUCCESS != sai_status)
+        if (SAI_NULL_OBJECT_ID != sai_object)
         {
-            SWSS_LOG_ERROR("Failed to remove buffer profile %s with type %s, rv:%d", object_name.c_str(), map_type_name.c_str(), sai_status);
-            task_process_status handle_status = handleSaiRemoveStatus(SAI_API_BUFFER, sai_status);
-            if (handle_status != task_process_status::task_success)
+            sai_status = sai_buffer_api->remove_buffer_profile(sai_object);
+            if (SAI_STATUS_SUCCESS != sai_status)
             {
-                return handle_status;
+                SWSS_LOG_ERROR("Failed to remove buffer profile %s with type %s, rv:%d", object_name.c_str(), map_type_name.c_str(), sai_status);
+                task_process_status handle_status = handleSaiRemoveStatus(SAI_API_BUFFER, sai_status);
+                if (handle_status != task_process_status::task_success)
+                {
+                    return handle_status;
+                }
             }
         }
 


### PR DESCRIPTION

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Don't call SAI API for BUFFER_POOL/PROFILE handling in case the op is DEL and the SAI OID is NULL in order to avoid orchagent from exiting.
We need it only in 202106 or above. In 202012 the orchagent won't exit in such case.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

**Why I did it**

**How I verified it**
Manually test.

**Details if related**
There is an optimization on orch: the SET event will be replaced by a DEL event
if it is still pending in m_toSync when the DEL event is coming.
This is reasonable but can cause the SAI OID to be NULL in rare case:
 - The application creates an object and then destroy it after a very short period
 - The create notification is eliminated and replaced by destroying the notification
 - The SAI object hasn't been created and is NULL when it is removed

This causes SAI error which eventually makes orchagent exit.
We need to avoid it in 202106 and above
(In 202012, the orchagent won't exit so it's ok to ignore the error)
The solution is not to call SAI removing interface in case SAI OID is NULL

It can happen if a user configures something which causes the accumulative headroom to exceed the limit.
In this case, the buffer profile was created and then removed in a short time.
