### PR TITLE
[201911][buffer manager] Reclaim unused buffer for admin-down ports

### DIFF
--- a/cfgmgr/buffermgr.cpp
+++ b/cfgmgr/buffermgr.cpp
@@ -112,7 +112,7 @@ Create/update two tables: profile (in m_cfgBufferProfileTable) and port buffer (
         }
     }
 */
-task_process_status BufferMgr::doSpeedUpdateTask(string port, string speed, bool admin_up)
+task_process_status BufferMgr::doPortTableUpdateTask(string port, string speed, bool admin_up)
 {
     vector<FieldValueTuple> fvVector;
     string cable;
@@ -237,10 +237,7 @@ void BufferMgr::doTask(Consumer &consumer)
                 // receive and cache cable length table
                 for (auto i : kfvFieldsValues(t))
                 {
-                    if (table_name == CFG_PORT_CABLE_LEN_TABLE_NAME)
-                    {
-                        task_status = doCableTask(fvField(i), fvValue(i));
-                    }
+                    task_status = doCableTask(fvField(i), fvValue(i));
                     if (task_status != task_process_status::task_success)
                     {
                         break;
@@ -266,7 +263,7 @@ void BufferMgr::doTask(Consumer &consumer)
                 }
 
                 if (speed_updated || admin_status_updated)
-                    task_status = doSpeedUpdateTask(port, speed, admin_up);
+                    task_status = doPortTableUpdateTask(port, speed, admin_up);
             }
         }
 

--- a/cfgmgr/buffermgr.h
+++ b/cfgmgr/buffermgr.h
@@ -45,7 +45,7 @@ private:
     std::string getPgPoolMode();
     void readPgProfileLookupFile(std::string);
     task_process_status doCableTask(std::string port, std::string cable_length);
-    task_process_status doSpeedUpdateTask(std::string port, std::string speed, bool admin_up);
+    task_process_status doPortTableUpdateTask(std::string port, std::string speed, bool admin_up);
 
     void doTask(Consumer &consumer);
 };

--- a/cfgmgr/buffermgr.h
+++ b/cfgmgr/buffermgr.h
@@ -45,7 +45,7 @@ private:
     std::string getPgPoolMode();
     void readPgProfileLookupFile(std::string);
     task_process_status doCableTask(std::string port, std::string cable_length);
-    task_process_status doSpeedUpdateTask(std::string port, std::string speed);
+    task_process_status doSpeedUpdateTask(std::string port, std::string speed, bool admin_up);
 
     void doTask(Consumer &consumer);
 };

--- a/tests/test_buffer_manager.py
+++ b/tests/test_buffer_manager.py
@@ -1,0 +1,72 @@
+import pytest
+import time
+from swsscommon import swsscommon
+
+class TestBufferManager(object):
+    def make_dict(self, input_list):
+        return dict(input_list[1])
+
+    def setup_db(self, dvs):
+        self.config_db = swsscommon.DBConnector(4, dvs.redis_sock, 0)
+        self.buffer_pg_table = swsscommon.Table(self.config_db, "BUFFER_PG")
+        self.port_table = swsscommon.Table(self.config_db, "PORT")
+        cable_length_table = swsscommon.Table(self.config_db, "CABLE_LENGTH")
+        cable_length_key = cable_length_table.getKeys()[0]
+        self.cable_lengths = self.make_dict(cable_length_table.get(cable_length_key))
+        self.buffer_profile_table = swsscommon.Table(self.config_db, "BUFFER_PROFILE")
+
+    def load_pg_profile_lookup(self, dvs):
+        self.profile_lookup_info = {}
+        lines = dvs.runcmd('cat /usr/share/sonic/hwsku/pg_profile_lookup.ini')[1].split('\n')
+
+        SPEED = 0
+        CABLE_LENGTH = 1
+        SIZE = 2
+        XON = 3
+        XOFF = 4
+        THRESHOLD = 5
+        XON_OFFSET = 6
+
+        for line in lines:
+            if len(line) == 0 or line[0] == '#':
+                continue
+            tokens = line.split()
+            self.profile_lookup_info[(tokens[SPEED], tokens[CABLE_LENGTH])] = {
+                'size': tokens[SIZE],
+                'xon': tokens[XON],
+                'xoff': tokens[XOFF],
+                'dynamic_th': tokens[THRESHOLD]
+            }
+            if XON_OFFSET < len(tokens):
+                self.profile_lookup_info[(tokens[SPEED], tokens[CABLE_LENGTH])]['xon_offset'] = tokens[XON_OFFSET]
+
+    def test_buffer_pg(self, dvs):
+        self.setup_db(dvs)
+
+        port = 'Ethernet0'
+        pg = port + '|3-4'
+
+        # At the beginning the port are admin down on VM. Make sure no lossless PG exists
+        assert not self.buffer_pg_table.get(pg)[0]
+
+        # Startup the port. The lossless PG should be created according to speed and cable length
+        dvs.runcmd('config interface startup {}'.format(port))
+
+        cable_length = self.cable_lengths.get(port)
+        port_info = self.make_dict(self.port_table.get(port))
+        speed = port_info.get('speed')
+
+        expected_profile_name = 'pg_lossless_{}_{}_profile'.format(speed, cable_length)
+        buffer_profile_info = self.make_dict(self.buffer_profile_table.get(expected_profile_name))
+        buffer_pg_info = self.make_dict(self.buffer_pg_table.get(pg))
+        assert buffer_pg_info['profile'] == '[BUFFER_PROFILE|{}]'.format(expected_profile_name)
+
+        self.load_pg_profile_lookup(dvs)
+        expected_profile_info = self.profile_lookup_info[(speed, cable_length)]
+        expected_profile_info['pool'] = '[BUFFER_POOL|ingress_lossless_pool]'
+        assert buffer_profile_info == expected_profile_info
+
+        # Shutdown the port. The lossless PG should be removed
+        dvs.runcmd('config interface shutdown {}'.format(port))
+        time.sleep(1)
+        assert not self.buffer_pg_table.get(pg)[0]


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Buffer manager handles port admin down.
- Don't apply lossless buffer PG to an admin-down port
- Remove lossless buffer PG (3-4) from a port when it is shut down.
- Readd lossless buffer PG (3-4) to a port when it is started up.

**Why I did it**

To support reclaiming reserved buffer when a port is shut down.

**How I verified it**

Regression test and vs test.

**Details if related**
