### PR TITLE
Reclaim unused buffer for both traditional and dynamic buffer model

### DIFF
--- a/cfgmgr/buffer_pool_mellanox.lua
+++ b/cfgmgr/buffer_pool_mellanox.lua
@@ -73,6 +73,37 @@ local function iterate_all_items(all_items, check_lossless)
     return 0
 end
 
+local function iterate_profile_list(all_items)
+    local port
+    for i = 1, #all_items, 1 do
+        port = string.match(all_items[i], "Ethernet%d+")
+        local profile_list = redis.call('HGET', all_items[i], 'profile_list')
+        if not profile_list then
+            return
+        end
+        for profile_name in string.gmatch(profile_list, "([^,]+)") do
+            -- The format of profile_list is profile_name,profile_name
+            -- We need to handle each of the profile in the list
+            -- The ingress_lossy_profile is shared by both BUFFER_PG|<port>|0 and BUFFER_PORT_INGRESS_PROFILE_LIST
+            -- It occupies buffers in BUFFER_PG but not in BUFFER_PORT_INGRESS_PROFILE_LIST
+            -- To distinguish both cases, a new name "ingress_lossy_profile_list" is introduced to indicate
+            -- the profile is used by the profile list where its size should be zero.
+            profile_name = string.sub(profile_name, 2, -2)
+            if profile_name == 'BUFFER_PROFILE_TABLE:ingress_lossy_profile' then
+                profile_name = profile_name .. '_list'
+                if profiles[profile_name] == nil then
+                    profiles[profile_name] = 0
+                end
+            end
+            local profile_ref_count = profiles[profile_name]
+            if profile_ref_count == nil then
+                return 1
+            end
+            profiles[profile_name] = profile_ref_count + 1
+        end
+    end
+end
+
 -- Connect to CONFIG_DB
 redis.call('SELECT', config_db)
 
@@ -82,7 +113,10 @@ total_port = #ports_table
 
 -- Initialize the port_set_8lanes set
 local lanes
-local number_of_lanes
+local number_of_lanes = 0
+local admin_status
+local admin_up_port = 0
+local admin_up_8lanes_port = 0
 local port
 for i = 1, total_port, 1 do
     -- Load lanes from PORT table
@@ -99,6 +133,14 @@ for i = 1, total_port, 1 do
             port_set_8lanes[port] = false
         end
     end
+    admin_status = redis.call('HGET', ports_table[i], 'admin_status')
+    if admin_status == 'up' then
+        admin_up_port = admin_up_port + 1
+        if (number_of_lanes == 8) then
+            admin_up_8lanes_port = admin_up_8lanes_port + 1
+        end
+    end
+    number_of_lanes = 0
 end
 
 local egress_lossless_pool_size = redis.call('HGET', 'BUFFER_POOL|egress_lossless_pool', 'size')
@@ -164,6 +206,12 @@ if fail_count > 0 then
     return {}
 end
 
+local all_ingress_profile_lists = redis.call('KEYS', 'BUFFER_PORT_INGRESS_PROFILE_LIST*')
+local all_egress_profile_lists = redis.call('KEYS', 'BUFFER_PORT_EGRESS_PROFILE_LIST*')
+
+iterate_profile_list(all_ingress_profile_lists)
+iterate_profile_list(all_egress_profile_lists)
+
 local statistics = {}
 
 -- Fetch sizes of all of the profiles, accumulate them
@@ -176,9 +224,6 @@ for name in pairs(profiles) do
         if size ~= nil then 
             if name == "BUFFER_PROFILE_TABLE:ingress_lossy_profile" then
                 size = size + lossypg_reserved
-            end
-            if name == "BUFFER_PROFILE_TABLE:egress_lossy_profile" then
-                profiles[name] = total_port
             end
             if size ~= 0 then
                 if shp_enabled and shp_size == 0 then
@@ -211,11 +256,11 @@ if shp_enabled then
 end
 
 -- Accumulate sizes for management PGs
-local accumulative_management_pg = (total_port - port_count_8lanes) * lossypg_reserved + port_count_8lanes * lossypg_reserved_8lanes
+local accumulative_management_pg = (admin_up_port - admin_up_8lanes_port) * lossypg_reserved + admin_up_8lanes_port * lossypg_reserved_8lanes
 accumulative_occupied_buffer = accumulative_occupied_buffer + accumulative_management_pg
 
 -- Accumulate sizes for egress mirror and management pool
-local accumulative_egress_mirror_overhead = total_port * egress_mirror_headroom
+local accumulative_egress_mirror_overhead = admin_up_port * egress_mirror_headroom
 accumulative_occupied_buffer = accumulative_occupied_buffer + accumulative_egress_mirror_overhead + mgmt_pool_size
 
 -- Switch to CONFIG_DB
@@ -295,5 +340,6 @@ table.insert(result, "debug:egress_mirror:" .. accumulative_egress_mirror_overhe
 table.insert(result, "debug:shp_enabled:" .. tostring(shp_enabled))
 table.insert(result, "debug:shp_size:" .. shp_size)
 table.insert(result, "debug:total port:" .. total_port .. " ports with 8 lanes:" .. port_count_8lanes)
+table.insert(result, "debug:admin up port:" .. admin_up_port .. " admin up ports with 8 lanes:" .. admin_up_8lanes_port)
 
 return result

--- a/cfgmgr/buffer_pool_mellanox.lua
+++ b/cfgmgr/buffer_pool_mellanox.lua
@@ -28,6 +28,13 @@ local port_set_8lanes = {}
 local lossless_port_count = 0
 
 local function iterate_all_items(all_items, check_lossless)
+    -- Iterates all items in all_items, check the buffer profile each item referencing, and update reference count accordingly
+    -- Arguments:
+    --     all_items is a list, holding all keys in BUFFER_PORT_INGRESS_PROFILE_LIST or BUFFER_PORT_EGRESS_PROFILE_LIST table
+    --     format of keys: <port name>|<ID map>, like Ethernet0|3-4
+    -- Return:
+    --     0 successful
+    --     1 failure, typically caused by the items just updated are still pended in orchagent's queue
     table.sort(all_items)
     local lossless_ports = {}
     local port
@@ -79,6 +86,13 @@ local function iterate_all_items(all_items, check_lossless)
 end
 
 local function iterate_profile_list(all_items)
+    -- Iterates all items in all_items, check the buffer profiles each item referencing, and update reference count accordingly
+    -- Arguments:
+    --     all_items is a list, holding all keys in BUFFER_PORT_INGRESS_PROFILE_LIST or BUFFER_PORT_EGRESS_PROFILE_LIST table
+    --     format of keys: <port name>
+    -- Return:
+    --     0 successful
+    --     1 failure, typically caused by the items just updated are still pended in orchagent's queue
     local port
     for i = 1, #all_items, 1 do
         -- XXX_TABLE_KEY_SET or XXX_TABLE_DEL_SET existing means the orchagent hasn't handled all updates

--- a/cfgmgr/buffer_pool_mellanox.lua
+++ b/cfgmgr/buffer_pool_mellanox.lua
@@ -191,7 +191,12 @@ local egress_lossless_pool_size = redis.call('HGET', 'BUFFER_POOL|egress_lossles
 
 -- Whether shared headroom pool is enabled?
 local default_lossless_param_keys = redis.call('KEYS', 'DEFAULT_LOSSLESS_BUFFER_PARAMETER*')
-local over_subscribe_ratio = tonumber(redis.call('HGET', default_lossless_param_keys[1], 'over_subscribe_ratio'))
+local over_subscribe_ratio
+if #default_lossless_param_keys > 0 then
+    over_subscribe_ratio = tonumber(redis.call('HGET', default_lossless_param_keys[1], 'over_subscribe_ratio'))
+else
+    over_subscribe_ratio = 0
+end
 
 -- Fetch the shared headroom pool size
 local shp_size = tonumber(redis.call('HGET', 'BUFFER_POOL|ingress_lossless_pool', 'xoff'))

--- a/cfgmgr/buffermgr.cpp
+++ b/cfgmgr/buffermgr.cpp
@@ -195,7 +195,7 @@ task_process_status BufferMgr::doSpeedUpdateTask(string port, bool admin_up)
 
     // check if profile already exists - if yes - skip creation
     m_cfgBufferProfileTable.get(buffer_profile_key, fvVector);
-    // Crete record in BUFFER_PROFILE table
+    // Create record in BUFFER_PROFILE table
     if (fvVector.size() == 0)
     {
         SWSS_LOG_NOTICE("Creating new profile '%s'", buffer_profile_key.c_str());

--- a/cfgmgr/buffermgr.h
+++ b/cfgmgr/buffermgr.h
@@ -36,6 +36,8 @@ public:
     using Orch::doTask;
 
 private:
+    std::string m_platform;
+
     Table m_cfgPortTable;
     Table m_cfgCableLenTable;
     Table m_cfgBufferProfileTable;
@@ -57,7 +59,7 @@ private:
     std::string getPgPoolMode();
     void readPgProfileLookupFile(std::string);
     task_process_status doCableTask(std::string port, std::string cable_length);
-    task_process_status doSpeedUpdateTask(std::string port);
+    task_process_status doSpeedUpdateTask(std::string port, bool admin_up);
     void doBufferTableTask(Consumer &consumer, ProducerStateTable &applTable);
 
     void transformSeperator(std::string &name);

--- a/cfgmgr/buffermgrd.cpp
+++ b/cfgmgr/buffermgrd.cpp
@@ -38,12 +38,13 @@ mutex gDbMutex;
 
 void usage()
 {
-    cout << "Usage: buffermgrd <-l pg_lookup.ini|-a asic_table.json [-p peripheral_table.json]>" << endl;
+    cout << "Usage: buffermgrd <-l pg_lookup.ini|-a asic_table.json [-p peripheral_table.json] [-z zero_profiles.json]>" << endl;
     cout << "       -l pg_lookup.ini: PG profile look up table file (mandatory for static mode)" << endl;
     cout << "           format: csv" << endl;
     cout << "           values: 'speed, cable, size, xon,  xoff, dynamic_threshold, xon_offset'" << endl;
     cout << "       -a asic_table.json: ASIC-specific parameters definition (mandatory for dynamic mode)" << endl;
-    cout << "       -p peripheral_table.json: Peripheral (eg. gearbox) parameters definition (mandatory for dynamic mode)" << endl;
+    cout << "       -p peripheral_table.json: Peripheral (eg. gearbox) parameters definition (optional for dynamic mode)" << endl;
+    cout << "       -z zero_profiles.json: Zero profiles definition for reclaiming unused buffers (optional for dynamic mode)" << endl;
 }
 
 void dump_db_item(KeyOpFieldsValuesTuple &db_item)
@@ -109,13 +110,13 @@ int main(int argc, char **argv)
     string pg_lookup_file = "";
     string asic_table_file = "";
     string peripherial_table_file = "";
-    string json_file = "";
+    string zero_profile_file = "";
     Logger::linkToDbNative("buffermgrd");
     SWSS_LOG_ENTER();
 
     SWSS_LOG_NOTICE("--- Starting buffermgrd ---");
 
-    while ((opt = getopt(argc, argv, "l:a:p:h")) != -1 )
+    while ((opt = getopt(argc, argv, "l:a:p:z:h")) != -1 )
     {
         switch (opt)
         {
@@ -131,6 +132,9 @@ int main(int argc, char **argv)
         case 'p':
             peripherial_table_file = optarg;
             break;
+        case 'z':
+            zero_profile_file = optarg;
+            break;
         default: /* '?' */
             usage();
             return EXIT_FAILURE;
@@ -141,7 +145,9 @@ int main(int argc, char **argv)
     {
         std::vector<Orch *> cfgOrchList;
         bool dynamicMode = false;
-        shared_ptr<vector<KeyOpFieldsValuesTuple>> db_items_ptr;
+        shared_ptr<vector<KeyOpFieldsValuesTuple>> asic_table_ptr = nullptr;
+        shared_ptr<vector<KeyOpFieldsValuesTuple>> peripherial_table_ptr = nullptr;
+        shared_ptr<vector<KeyOpFieldsValuesTuple>> zero_profiles_ptr = nullptr;
 
         DBConnector cfgDb("CONFIG_DB", 0);
         DBConnector stateDb("STATE_DB", 0);
@@ -150,18 +156,23 @@ int main(int argc, char **argv)
         if (!asic_table_file.empty())
         {
             // Load the json file containing the SWITCH_TABLE
-            db_items_ptr = load_json(asic_table_file);
-            if (nullptr != db_items_ptr)
+            asic_table_ptr = load_json(asic_table_file);
+            if (nullptr != asic_table_ptr)
             {
-                write_to_state_db(db_items_ptr);
-                db_items_ptr.reset();
+                write_to_state_db(asic_table_ptr);
 
                 if (!peripherial_table_file.empty())
                 {
                     //Load the json file containing the PERIPHERIAL_TABLE
-                    db_items_ptr = load_json(peripherial_table_file);
-                    if (nullptr != db_items_ptr)
-                        write_to_state_db(db_items_ptr);
+                    peripherial_table_ptr = load_json(peripherial_table_file);
+                    if (nullptr != peripherial_table_ptr)
+                        write_to_state_db(peripherial_table_ptr);
+                }
+
+                if (!zero_profile_file.empty())
+                {
+                    //Load the json file containing the zero profiles
+                    zero_profiles_ptr = load_json(zero_profile_file);
                 }
 
                 dynamicMode = true;
@@ -183,7 +194,7 @@ int main(int argc, char **argv)
                 TableConnector(&stateDb, STATE_BUFFER_MAXIMUM_VALUE_TABLE),
                 TableConnector(&stateDb, STATE_PORT_TABLE_NAME)
             };
-            cfgOrchList.emplace_back(new BufferMgrDynamic(&cfgDb, &stateDb, &applDb, buffer_table_connectors, db_items_ptr));
+            cfgOrchList.emplace_back(new BufferMgrDynamic(&cfgDb, &stateDb, &applDb, buffer_table_connectors, peripherial_table_ptr, zero_profiles_ptr));
         }
         else if (!pg_lookup_file.empty())
         {

--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -658,6 +658,26 @@ void BufferMgrDynamic::recalculateSharedBufferPool()
         vector<string> keys = {};
         vector<string> argv = {};
 
+        if (!m_bufferPoolReady)
+        {
+            // In case all buffer pools have a configured size,
+            // The m_bufferPoolReady will be set to true
+            // It can happen on vs.
+            bool hasDynamicSizePool = false;
+            for (auto &poolRef : m_bufferPoolLookup)
+            {
+                if (poolRef.second.dynamic_size)
+                {
+                    hasDynamicSizePool = true;
+                }
+            }
+            if (!hasDynamicSizePool)
+            {
+                m_bufferPoolReady = true;
+                SWSS_LOG_NOTICE("No pool requires calculating size dynamically. All buffer pools are ready");
+            }
+        }
+
         auto ret = runRedisScript(*m_applDb, m_bufferpoolSha, keys, argv);
 
         // The format of the result:

--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -1180,6 +1180,7 @@ void BufferMgrDynamic::removeZeroProfilesOnPort(port_info_t &portInfo, const str
         {
             m_applBufferQueueTable.del(portPrefix + it);
         }
+        portInfo.supported_but_not_configured_queues.clear();
     }
 }
 
@@ -3176,15 +3177,11 @@ void BufferMgrDynamic::handlePendingBufferObjects()
             {
                 if (port.second.state != PORT_ADMIN_DOWN)
                 {
+                    // The admin-down ports should not be touched here. Two scenarios
+                    // 1. If admin-status is handled ahead of m_bufferPoolReady being true,
+                    //    They should be in m_pendingApplyZeroProfilePorts and will be handled later in this function
+                    // 2. Otherwise, they should have been handled and zero profiles have been applied.
                     refreshPgsForPort(port.first, port.second.effective_speed, port.second.cable_length, port.second.mtu);
-                    for (auto &pg : m_portPgLookup[port.first])
-                    {
-                        if (!pg.second.lossless)
-                        {
-                            auto const &reference = "[BUFFER_PROFILE_TABLE:" + pg.second.running_profile_name + "]";
-                            updateBufferObjectToDb(pg.first, reference, true);
-                        }
-                    }
                 }
             }
 

--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -2707,9 +2707,21 @@ void BufferMgrDynamic::handleSetSingleBufferObjectOnAdminDonwPort(bool isPg, con
     {
         // Notify APPL_DB to add zero profile to items
         // An side effect is the items will be ready in orchagent (added to m_ready_list)
-        auto &profileInfo = m_bufferProfileLookup[profile];
-        auto &poolInfo = m_bufferPoolLookup[profileInfo.pool_name];
-        updateBufferObjectToDb(key, poolInfo.zero_profile_name, true, false);
+        string zeroProfile;
+        auto const &searchRef = m_bufferProfileLookup.find(profile);
+        if (searchRef == m_bufferProfileLookup.end())
+        {
+            // In this case, we shouldn't set the dynamic calculated flag to true
+            // It will be updated when its profile configured.
+            zeroProfile = isPg ? m_ingressPgZeroProfileName : m_egressQueueZeroProfileName;
+        }
+        else
+        {
+            auto &profileInfo = searchRef->second;
+            auto &poolInfo = m_bufferPoolLookup[profileInfo.pool_name];
+            zeroProfile = poolInfo.zero_profile_name;
+        }
+        updateBufferObjectToDb(key, zeroProfile, true, false);
     }
 }
 

--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -2693,7 +2693,6 @@ task_process_status BufferMgrDynamic::handleSingleBufferPgEntry(const string &ke
     SWSS_LOG_DEBUG("Processing command:%s table BUFFER_PG key %s", op.c_str(), key.c_str());
     if (op == SET_COMMAND)
     {
-        bool ignored = false;
         bool pureDynamic = true;
         // For set command:
         // 1. Create the corresponding table entries in APPL_DB
@@ -2763,7 +2762,7 @@ task_process_status BufferMgrDynamic::handleSingleBufferPgEntry(const string &ke
             bufferPg.lossless = true;
         }
 
-        if (!ignored && bufferPg.lossless)
+        if (bufferPg.lossless)
         {
             doUpdatePgTask(key, port);
         }

--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -2283,8 +2283,14 @@ task_process_status BufferMgrDynamic::handleBufferProfileTable(KeyOpFieldsValues
         }
 
         // Don't insert dynamically calculated profiles into APPL_DB
-        if (profileApp.lossless && profileApp.ingress)
+        if (profileApp.lossless)
         {
+            if (!profileApp.ingress)
+            {
+                SWSS_LOG_ERROR("BUFFER_PROFILE %s is ingress but referencing an egress pool %s", profileName.c_str(), profileApp.pool_name.c_str());
+                return task_process_status::task_success;
+            }
+
             if (profileApp.dynamic_calculated)
             {
                 profileApp.state = PROFILE_NORMAL;

--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -893,7 +893,7 @@ void BufferMgrDynamic::updateBufferObjectToDb(const string &key, const string &p
         }
 
         vector<FieldValueTuple> fvVector;
-        fvVector.emplace_back("profile", profile);
+        fvVector.emplace_back(buffer_profile_field_name, profile);
 
         table.set(key, fvVector);
     }
@@ -917,7 +917,7 @@ void BufferMgrDynamic::updateBufferObjectListToDb(const string &key, const strin
 
     vector<FieldValueTuple> fvVector;
 
-    fvVector.emplace_back("profile_list", profileList);
+    fvVector.emplace_back(buffer_profile_list_field_name, profileList);
 
     table.set(key, fvVector);
 }
@@ -1209,7 +1209,7 @@ void BufferMgrDynamic::applyNormalBufferObjectsOnPort(const string &port)
     auto &ingressProfileList = m_portIngressProfileListLookup[port];
     if (!ingressProfileList.empty())
     {
-        fvVector.emplace_back("profile_list", ingressProfileList);
+        fvVector.emplace_back(buffer_profile_list_field_name, ingressProfileList);
         m_applBufferIngressProfileListTable.set(port, fvVector);
         fvVector.clear();
     }
@@ -1217,7 +1217,7 @@ void BufferMgrDynamic::applyNormalBufferObjectsOnPort(const string &port)
     auto egressProfileList = m_portEgressProfileListLookup[port];
     if (!egressProfileList.empty())
     {
-        fvVector.emplace_back("profile_list", egressProfileList);
+        fvVector.emplace_back(buffer_profile_list_field_name, egressProfileList);
         m_applBufferEgressProfileListTable.set(port, fvVector);
         fvVector.clear();
     }
@@ -1501,7 +1501,7 @@ task_process_status BufferMgrDynamic::reclaimReservedBufferForPort(const string 
     if (ingressProfileListRef != m_portIngressProfileListLookup.end())
     {
         const string &zeroIngressProfileNameList = constructZeroProfileListFromNormalProfileList(ingressProfileListRef->second, port);
-        fvVector.emplace_back("profile_list", zeroIngressProfileNameList);
+        fvVector.emplace_back(buffer_profile_list_field_name, zeroIngressProfileNameList);
         m_applBufferIngressProfileListTable.set(port, fvVector);
         fvVector.clear();
     }
@@ -1511,7 +1511,7 @@ task_process_status BufferMgrDynamic::reclaimReservedBufferForPort(const string 
     if (egressProfileListRef != m_portEgressProfileListLookup.end())
     {
         const string &zeroEgressProfileNameList = constructZeroProfileListFromNormalProfileList(egressProfileListRef->second, port);
-        fvVector.emplace_back("profile_list", zeroEgressProfileNameList);
+        fvVector.emplace_back(buffer_profile_list_field_name, zeroEgressProfileNameList);
         m_applBufferEgressProfileListTable.set(port, fvVector);
         fvVector.clear();
     }
@@ -2927,7 +2927,7 @@ task_process_status BufferMgrDynamic::handleSingleBufferQueueEntry(const string 
         for (auto i : kfvFieldsValues(tuple))
         {
             // Transform the separator in values from "|" to ":"
-            if (fvField(i) == "profile")
+            if (fvField(i) == buffer_profile_field_name)
             {
                 transformReference(fvValue(i));
                 auto rc = checkBufferProfileDirection(fvValue(i), false);
@@ -2995,7 +2995,7 @@ task_process_status BufferMgrDynamic::handleSingleBufferPortProfileListEntry(con
 
         for (auto i : kfvFieldsValues(tuple))
         {
-            if (fvField(i) == "profile_list")
+            if (fvField(i) == buffer_profile_list_field_name)
             {
                 transformReference(fvValue(i));
                 auto rc = checkBufferProfileDirection(fvValue(i), ingress);

--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -2312,8 +2312,6 @@ task_process_status BufferMgrDynamic::handleBufferProfileTable(KeyOpFieldsValues
         {
             SWSS_LOG_NOTICE("BUFFER_PROFILE %s has been inserted into APPL_DB directly", profileName.c_str());
             updateBufferProfileToDb(profileName, profileApp);
-
-            m_bufferProfileIgnored.insert(profileName);
         }
     }
     else if (op == DEL_COMMAND)
@@ -2350,7 +2348,6 @@ task_process_status BufferMgrDynamic::handleBufferProfileTable(KeyOpFieldsValues
             }
 
             m_bufferProfileLookup.erase(profileName);
-            m_bufferProfileIgnored.erase(profileName);
         }
         else
         {
@@ -2410,22 +2407,11 @@ task_process_status BufferMgrDynamic::handleSingleBufferPgEntry(const string &ke
                 auto searchRef = m_bufferProfileLookup.find(profileName);
                 if (searchRef == m_bufferProfileLookup.end())
                 {
-                    if (m_bufferProfileIgnored.find(profileName) != m_bufferProfileIgnored.end())
-                    {
-                        // Referencing an ignored profile, the PG should be ignored as well
-                        ignored = true;
-                        bufferPg.dynamic_calculated = false;
-                        bufferPg.lossless = false;
-                        bufferPg.configured_profile_name = profileName;
-                    }
-                    else
-                    {
-                        // In this case, we shouldn't set the dynamic calculated flag to true
-                        // It will be updated when its profile configured.
-                        bufferPg.dynamic_calculated = false;
-                        SWSS_LOG_WARN("Profile %s hasn't been configured yet, skip", profileName.c_str());
-                        return task_process_status::task_need_retry;
-                    }
+                    // In this case, we shouldn't set the dynamic calculated flag to true
+                    // It will be updated when its profile configured.
+                    bufferPg.dynamic_calculated = false;
+                    SWSS_LOG_WARN("Profile %s hasn't been configured yet, skip", profileName.c_str());
+                    return task_process_status::task_need_retry;
                 }
                 else
                 {

--- a/cfgmgr/buffermgrdyn.h
+++ b/cfgmgr/buffermgrdyn.h
@@ -196,9 +196,6 @@ private:
     // 2. Dynamically calculated headroom info stored in APPL_BUFFER_PROFILE
     // key: profile name
     buffer_profile_lookup_t m_bufferProfileLookup;
-    // A set where the ignored profiles are stored.
-    // A PG that reference an ignored profile should also be ignored.
-    std::set<std::string> m_bufferProfileIgnored;
 
     // BUFFER_PG table and caches
     ProducerStateTable m_applBufferPgTable;

--- a/cfgmgr/buffermgrdyn.h
+++ b/cfgmgr/buffermgrdyn.h
@@ -167,6 +167,7 @@ private:
     std::set<std::string> m_zeroPoolNameSet;
     std::vector<std::pair<std::string, std::string>> m_zeroProfiles;
     bool m_zeroProfilesLoaded;
+    bool m_supportRemoving;
     std::string m_ingressPgZeroProfileName;
     std::string m_egressQueueZeroProfileName;
     std::string m_pgIdsToZero;
@@ -270,7 +271,7 @@ private:
     // APPL_DB table operations
     void updateBufferPoolToDb(const std::string &name, const buffer_pool_t &pool);
     void updateBufferProfileToDb(const std::string &name, const buffer_profile_t &profile);
-    void updateBufferObjectToDb(const std::string &key, const std::string &profile, bool add, bool isPg);
+    void updateBufferObjectToDb(const std::string &key, const std::string &profile, bool add, bool isPg, bool isReference);
     void updateBufferObjectListToDb(const std::string &key, const std::string &profileList, bool ingress);
 
     // Meta flows
@@ -284,13 +285,12 @@ private:
     void refreshSharedHeadroomPool(bool enable_state_updated_by_ratio, bool enable_state_updated_by_size);
     task_process_status checkBufferProfileDirection(const std::string &profiles, bool expectIngress);
     std::string constructZeroProfileListFromNormalProfileList(const std::string &normalProfileList, const std::string &port);
-    task_process_status applyZeroProfilesOnPort(port_info_t &portInfo, const std::string &port);
     void removeZeroProfilesOnPort(port_info_t &portInfo, const std::string &port);
     void applyNormalBufferObjectsOnPort(const std::string &port);
     void handlePendingBufferObjects();
 
     // Main flows
-    task_process_status removeAllBufferObjectsFromPort(const std::string &port);
+    task_process_status reclaimReservedBufferForPort(const std::string &port);
     task_process_status refreshPgsForPort(const std::string &port, const std::string &speed, const std::string &cable_length, const std::string &mtu, const std::string &exactly_matched_key);
     task_process_status doUpdatePgTask(const std::string &pg_key, const std::string &port);
     task_process_status doRemovePgTask(const std::string &pg_key, const std::string &port);

--- a/cfgmgr/buffermgrdyn.h
+++ b/cfgmgr/buffermgrdyn.h
@@ -102,6 +102,8 @@ typedef struct {
     std::string supported_speeds;
 
     long lane_count;
+    std::string queues_to_reclaim;
+    std::string pgs_to_reclaim;
 } port_info_t;
 
 //TODO:
@@ -282,7 +284,7 @@ private:
     void refreshSharedHeadroomPool(bool enable_state_updated_by_ratio, bool enable_state_updated_by_size);
     task_process_status checkBufferProfileDirection(const std::string &profiles, bool expectIngress);
     std::string constructZeroProfileListFromNormalProfileList(const std::string &normalProfileList, const std::string &port);
-    void applyZeroProfilesOnPort(const std::string &port);
+    task_process_status applyZeroProfilesOnPort(const std::string &port);
     void removeZeroProfilesOnPort(const std::string &port);
     void applyNormalBufferObjectsOnPort(const std::string &port);
 

--- a/cfgmgr/buffermgrdyn.h
+++ b/cfgmgr/buffermgrdyn.h
@@ -103,11 +103,9 @@ typedef struct {
 
     long lane_count;
     sai_uint32_t maximum_queues;
-    long queues_map;
-    std::vector<std::string> extra_queues;
+    std::vector<std::string> supported_but_not_configured_queues;
     sai_uint32_t maximum_pgs;
-    long pgs_map;
-    std::vector<std::string> extra_pgs;
+    std::vector<std::string> supported_but_not_configured_pgs;
 } port_info_t;
 
 //TODO:
@@ -271,8 +269,8 @@ private:
         return !value.empty() && value != "0";
     }
     std::string getMaxSpeedFromList(std::string speedList);
-    std::vector<std::string> generateSupportedButNotConfiguredItemsMap(long idsMap, sai_uint32_t maxId);
-    void updateReclaimedItemsToMap(const std::string &key, long &idsMap);
+    std::vector<std::string> generateSupportedButNotConfiguredItemsMap(unsigned long idsMap, sai_uint32_t maxId);
+    void clearIdsFromMap(const std::string &key, unsigned long &idsMap);
 
     // APPL_DB table operations
     void updateBufferPoolToDb(const std::string &name, const buffer_pool_t &pool);

--- a/cfgmgr/buffermgrdyn.h
+++ b/cfgmgr/buffermgrdyn.h
@@ -275,7 +275,7 @@ private:
     // APPL_DB table operations
     void updateBufferPoolToDb(const std::string &name, const buffer_pool_t &pool);
     void updateBufferProfileToDb(const std::string &name, const buffer_profile_t &profile);
-    void updateBufferObjectToDb(const std::string &key, const std::string &profile, bool add, bool isPg, bool isReference);
+    void updateBufferObjectToDb(const std::string &key, const std::string &profile, bool add, bool isPg);
     void updateBufferObjectListToDb(const std::string &key, const std::string &profileList, bool ingress);
 
     // Meta flows

--- a/cfgmgr/buffermgrdyn.h
+++ b/cfgmgr/buffermgrdyn.h
@@ -269,7 +269,7 @@ private:
         return !value.empty() && value != "0";
     }
     std::string getMaxSpeedFromList(std::string speedList);
-    std::vector<std::string> generateSupportedButNotConfiguredItemsMap(unsigned long idsMap, sai_uint32_t maxId);
+    std::vector<std::string> generateIdListFromMap(unsigned long idsMap, sai_uint32_t maxId);
     void clearIdsFromMap(const std::string &key, unsigned long &idsMap);
 
     // APPL_DB table operations
@@ -289,7 +289,7 @@ private:
     void refreshSharedHeadroomPool(bool enable_state_updated_by_ratio, bool enable_state_updated_by_size);
     task_process_status checkBufferProfileDirection(const std::string &profiles, bool expectIngress);
     std::string constructZeroProfileListFromNormalProfileList(const std::string &normalProfileList, const std::string &port);
-    void removeZeroProfilesOnPort(port_info_t &portInfo, const std::string &port);
+    void removeSupportedButNotConfiguredItemsOnPort(port_info_t &portInfo, const std::string &port);
     void applyNormalBufferObjectsOnPort(const std::string &port);
     void handlePendingBufferObjects();
     void handleSetSingleBufferObjectOnAdminDonwPort(bool isPg, const std::string &port, const std::string &key, const std::string &profile);

--- a/cfgmgr/buffermgrdyn.h
+++ b/cfgmgr/buffermgrdyn.h
@@ -154,7 +154,8 @@ private:
     buffer_single_item_handler_map m_bufferSingleItemHandlerMap;
 
     bool m_portInitDone;
-    bool m_firstTimeCalculateBufferPool;
+    bool m_bufferPoolReady;
+    bool m_bufferObjectsPending;
 
     std::string m_configuredSharedHeadroomPoolSize;
 
@@ -271,7 +272,8 @@ private:
     // APPL_DB table operations
     void updateBufferPoolToDb(const std::string &name, const buffer_pool_t &pool);
     void updateBufferProfileToDb(const std::string &name, const buffer_profile_t &profile);
-    void updateBufferPgToDb(const std::string &key, const std::string &profile, bool add);
+    void updateBufferObjectToDb(const std::string &key, const std::string &profile, bool add, bool isPg);
+    void updateBufferObjectListToDb(const std::string &key, const std::string &profileList, bool ingress);
 
     // Meta flows
     bool needRefreshPortDueToEffectiveSpeed(port_info_t &portInfo, std::string &portName);
@@ -287,6 +289,7 @@ private:
     task_process_status applyZeroProfilesOnPort(const std::string &port);
     void removeZeroProfilesOnPort(const std::string &port);
     void applyNormalBufferObjectsOnPort(const std::string &port);
+    void handlePendingBufferObjects();
 
     // Main flows
     task_process_status removeAllBufferObjectsFromPort(const std::string &port);

--- a/cfgmgr/buffermgrdyn.h
+++ b/cfgmgr/buffermgrdyn.h
@@ -292,6 +292,8 @@ private:
     void removeZeroProfilesOnPort(port_info_t &portInfo, const std::string &port);
     void applyNormalBufferObjectsOnPort(const std::string &port);
     void handlePendingBufferObjects();
+    void handleSetSingleBufferObjectOnAdminDonwPort(bool isPg, const std::string &port, const std::string &key, const std::string &profile);
+    void handleDelSingleBufferObjectOnAdminDonwPort(bool isPg, const std::string &port, const std::string &key, port_info_t &portInfo);
 
     // Main flows
     task_process_status reclaimReservedBufferForPort(const std::string &port);

--- a/cfgmgr/buffermgrdyn.h
+++ b/cfgmgr/buffermgrdyn.h
@@ -164,7 +164,8 @@ private:
 
     // Fields for zero pool and profiles
     std::vector<KeyOpFieldsValuesTuple> m_zeroPoolAndProfileInfo;
-    std::vector<std::pair<std::string, std::string>> m_zeroPoolAndProfileNames;
+    std::set<std::string> m_zeroPoolNameSet;
+    std::vector<std::pair<std::string, std::string>> m_zeroProfiles;
     bool m_zeroProfilesLoaded;
     std::string m_ingressPgZeroProfileName;
     std::string m_egressQueueZeroProfileName;
@@ -283,8 +284,8 @@ private:
     void refreshSharedHeadroomPool(bool enable_state_updated_by_ratio, bool enable_state_updated_by_size);
     task_process_status checkBufferProfileDirection(const std::string &profiles, bool expectIngress);
     std::string constructZeroProfileListFromNormalProfileList(const std::string &normalProfileList, const std::string &port);
-    task_process_status applyZeroProfilesOnPort(const std::string &port);
-    void removeZeroProfilesOnPort(const std::string &port);
+    task_process_status applyZeroProfilesOnPort(port_info_t &portInfo, const std::string &port);
+    void removeZeroProfilesOnPort(port_info_t &portInfo, const std::string &port);
     void applyNormalBufferObjectsOnPort(const std::string &port);
     void handlePendingBufferObjects();
 

--- a/cfgmgr/buffermgrdyn.h
+++ b/cfgmgr/buffermgrdyn.h
@@ -102,8 +102,12 @@ typedef struct {
     std::string supported_speeds;
 
     long lane_count;
-    std::string queues_to_reclaim;
-    std::string pgs_to_reclaim;
+    sai_uint32_t maximum_queues;
+    long queues_map;
+    std::vector<std::string> extra_queues;
+    sai_uint32_t maximum_pgs;
+    long pgs_map;
+    std::vector<std::string> extra_pgs;
 } port_info_t;
 
 //TODO:
@@ -267,6 +271,8 @@ private:
         return !value.empty() && value != "0";
     }
     std::string getMaxSpeedFromList(std::string speedList);
+    std::vector<std::string> generateSupportedButNotConfiguredItemsMap(long idsMap, sai_uint32_t maxId);
+    void updateReclaimedItemsToMap(const std::string &key, long &idsMap);
 
     // APPL_DB table operations
     void updateBufferPoolToDb(const std::string &name, const buffer_pool_t &pool);

--- a/cfgmgr/buffermgrdyn.h
+++ b/cfgmgr/buffermgrdyn.h
@@ -271,6 +271,7 @@ private:
     std::string getMaxSpeedFromList(std::string speedList);
     std::vector<std::string> generateIdListFromMap(unsigned long idsMap, sai_uint32_t maxId);
     void clearIdsFromMap(const std::string &key, unsigned long &idsMap);
+    std::string &fetchZeroProfileFromNormalProfile(const std::string &profile);
 
     // APPL_DB table operations
     void updateBufferPoolToDb(const std::string &name, const buffer_pool_t &pool);

--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -204,6 +204,12 @@ bool BufferOrch::isPortReady(const std::string& port_name) const
     return result;
 }
 
+void BufferOrch::clearBufferPoolWatermarkCounterCounterIdList(const sai_object_id_t object_id)
+{
+    string key = BUFFER_POOL_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP ":" + sai_serialize_object_id(object_id);
+    m_flexCounterTable->del(key);
+}
+
 void BufferOrch::generateBufferPoolWatermarkCounterIdList(void)
 {
     // This function will be called in FlexCounterOrch when field:value tuple "FLEX_COUNTER_STATUS":"enable"
@@ -454,6 +460,7 @@ task_process_status BufferOrch::processBufferPool(KeyOpFieldsValuesTuple &tuple)
 
         if (SAI_NULL_OBJECT_ID != sai_object)
         {
+            clearBufferPoolWatermarkCounterCounterIdList(sai_object);
             sai_status = sai_buffer_api->remove_buffer_pool(sai_object);
             if (SAI_STATUS_SUCCESS != sai_status)
             {

--- a/orchagent/bufferorch.h
+++ b/orchagent/bufferorch.h
@@ -45,6 +45,7 @@ private:
 
     void doTask() override;
     virtual void doTask(Consumer& consumer);
+    void clearBufferPoolWatermarkCounterCounterIdList(const sai_object_id_t object_id);
     void initTableHandlers();
     void initBufferReadyLists(DBConnector *confDb, DBConnector *applDb);
     void initBufferReadyList(Table& table, bool isConfigDb);

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4013,7 +4013,10 @@ void PortsOrch::initializePortMaximumHeadroom(Port &port)
 void PortsOrch::initializePortBufferMaximumParameters(Port &port)
 {
     vector<FieldValueTuple> fvVector;
-    fvVector.emplace_back("max_headroom_size", to_string(port.m_maximum_headroom));
+    if (port.m_maximum_headroom > 0)
+    {
+        fvVector.emplace_back("max_headroom_size", to_string(port.m_maximum_headroom));
+    }
     fvVector.emplace_back("max_priority_groups", to_string(port.m_priority_group_ids.size()));
     fvVector.emplace_back("max_queues", to_string(port.m_queue_ids.size()));
 

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4007,9 +4007,16 @@ void PortsOrch::initializePortMaximumHeadroom(Port &port)
         return;
     }
 
-    vector<FieldValueTuple> fvVector;
     port.m_maximum_headroom = attr.value.u32;
+}
+
+void PortsOrch::initializePortBufferMaximumParameters(Port &port)
+{
+    vector<FieldValueTuple> fvVector;
     fvVector.emplace_back("max_headroom_size", to_string(port.m_maximum_headroom));
+    fvVector.emplace_back("max_priority_groups", to_string(port.m_priority_group_ids.size()));
+    fvVector.emplace_back("max_queues", to_string(port.m_queue_ids.size()));
+
     m_stateBufferMaximumValueTable->set(port.m_alias, fvVector);
 }
 
@@ -4022,6 +4029,7 @@ bool PortsOrch::initializePort(Port &port)
     initializePriorityGroups(port);
     initializeQueues(port);
     initializePortMaximumHeadroom(port);
+    initializePortBufferMaximumParameters(port);
 
     /* Create host interface */
     if (!addHostIntfs(port, port.m_alias, port.m_hif_id))

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -240,6 +240,7 @@ private:
     bool initializePort(Port &port);
     void initializePriorityGroups(Port &port);
     void initializePortMaximumHeadroom(Port &port);
+    void initializePortBufferMaximumParameters(Port &port);
     void initializeQueues(Port &port);
 
     bool addHostIntfs(Port &port, string alias, sai_object_id_t &host_intfs_id);

--- a/tests/test_buffer_dynamic.py
+++ b/tests/test_buffer_dynamic.py
@@ -585,7 +585,7 @@ class TestBufferMgrDyn(object):
         self.app_db.wait_for_deleted_entry("BUFFER_PG_TABLE", "Ethernet0:6")
         self.app_db.wait_for_deleted_entry("BUFFER_QUEUE_TABLE", "Ethernet0:7")
 
-        # Startup port and check whether all the PGs haved been added
+        # Startup port and check whether all the PGs have been added
         dvs.runcmd("config interface startup Ethernet0")
         self.app_db.wait_for_field_match("BUFFER_PG_TABLE", "Ethernet0:0", {"profile": lossy_pg_reference_appl_db})
         self.app_db.wait_for_field_match("BUFFER_PG_TABLE", "Ethernet0:1", {"profile": lossy_pg_reference_appl_db})


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Reclaim reserved buffer of unused ports for both dynamic and traditional models.
This is done by 
- Removing lossless priority groups on unused ports.
- Applying zero buffer profiles on the buffer objects of unused ports.
- In the dynamic buffer model, the zero profiles are loaded from a JSON file and applied to `APPL_DB` if there are admin down ports.
  The default buffer configuration will be configured on all ports. Buffer manager will apply zero profiles on admin down ports.
- In the static buffer model, the zero profiles are loaded by the buffer template.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

**Why I did it**

**How I verified it**

Regression test and vs test.

**Details if related**
***Static buffer model***

Remove the lossless buffer priority group if the port is admin-down and the buffer profile aligns with the speed and cable length of the port.

***Dynamic buffer model***

****Handle zero buffer pools and profiles****

1. buffermgrd: add a CLI option to load the JSON file for zero profiles.
2. Load them from JSON file into the internal buffer manager's data structure
3. Apply them to APPL_DB once there is at least one admin-down port
   - Record zero profiles' names in the pool object it references.
     By doing so, the zero profile lists can be constructed according to the normal profile list. There should be one profile for each pool on the ingress/egress side.
   - And then apply the zero profiles to the buffer objects of the port.
   - Unload them from APPL_DB once all ports are admin-up since the zero pools and profiles are no longer referenced.
     Remove buffer pool counter id when the zero pool is removed.
4. Now that it's possible that a pool will be removed from the system, the watermark counter of the pool is removed ahead of the pool itself being removed.

****Handle port admin status change****

1. Currently, there is a logic of removing buffer priority groups of admin down ports. This logic will be reused and extended for all buffer objects, including `BUFFER_QUEUE`, `BUFFER_PORT_INGRESS_PROFILE_LIST`, and `BUFFER_PORT_EGRESS_PROFILE_LIST`.
   - When the port is admin down,
     - The normal profiles are removed from the buffer objects of the port
     - The zero profiles, if provided, are applied to the port
   - When the port is admin up,
     - The zero profiles, if applied, are removed from the port
     - The normal profiles are applied to the port.
2. Ports orchagent exposes the number of queues and priority groups to STATE_DB.
   Buffer manager can take advantage of these values to apply zero profiles on all the priority groups and queues of the admin-down ports.
   In case it is not necessary to apply zero profiles on all priority groups or queues on a certain platform, `ids_to_reclaim` can be customized in the JSON file.
3. Handle all buffer tables, including `BUFFER_PG`, `BUFFER_QUEUE`, `BUFFER_PORT_INGRESS_PROFILE_LIST` and `BUFFER_PORT_EGRESS_PROFILE_LIST`
   - Originally, only the `BUFFER_PG` table was cached in the dynamic buffer manager.
   - Now, all tables are cached in order to apply zero profiles when a port is admin down and apply normal profiles when it's up.
   - The index of such tables can include a single port or a list of ports, like `BUFFER_PG|Ethernet0|3-4` or `BUFFER_PG|Ethernet0,Ethernet4,Ethernet8|3-4`. Originally, there is a logic to handle such indexes for the `BUFFER_PG` table. Now it is reused and extended to handle all the tables.
4. [Mellanox] Plugin to calculate buffer pool size:
   - Originally, buffer for the queue, buffer profile list, etc. were not reclaimed for admin-down ports so they are reserved for all ports.
   - Now, they are reserved for admin-up ports only.

****Accelerate the progress of applying buffer tables to APPL_DB****

This is an optimization on top of reclaiming buffer.

1. Don't apply buffer profiles, buffer objects to `APPL_DB` before buffer pools are applied when the system is starting.
   This is to apply the items in an order from referenced items to referencing items and try to avoid buffer orchagent retrying due to referenced table items.
   However, it is still possible that the referencing items are handled before referenced items. In that case, there should not be any error message.
2. [Mellanox] Plugin to calculate buffer pool size:
   Return the buffer pool sizes value currently in APPL_DB if the pool sizes are not able to be calculated due to lacking some information. This typically happens at the system start.
   This is to accelerate the progress of pushing tables to APPL_DB.
