### PR TITLE
Fix issue: accumulative headroom can exceed limit in rare scenario

### DIFF
--- a/cfgmgr/buffer_check_headroom_mellanox.lua
+++ b/cfgmgr/buffer_check_headroom_mellanox.lua
@@ -22,6 +22,8 @@ end
 -- Initialize the accumulative size with 4096
 -- This is to absorb the possible deviation
 local accumulative_size = 4096
+-- Egress mirror size: 2 * maximum MTU (10k)
+local egress_mirror_size = 20*1024
 
 local appl_db = "0"
 local state_db = "6"
@@ -56,8 +58,9 @@ local pipeline_latency = tonumber(redis.call('HGET', asic_keys[1], 'pipeline_lat
 if is_port_with_8lanes(lanes) then
     -- The pipeline latency should be adjusted accordingly for ports with 2 buffer units
     pipeline_latency = pipeline_latency * 2 - 1
+    egress_mirror_size = egress_mirror_size * 2
 end
-accumulative_size = accumulative_size + 2 * pipeline_latency * 1024
+accumulative_size = accumulative_size + 2 * pipeline_latency * 1024 + egress_mirror_size
 
 -- Fetch all keys in BUFFER_PG according to the port
 redis.call('SELECT', appl_db)


### PR DESCRIPTION
The egress mirror size is not accurate,
causing the estimated accumulative headroom size to be greater
than the real one

Signed-off-by: Stephen Sun <stephens@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
