### PR TITLE
Revert "Revert "[buffer orch] Bugfix: Don't query counter SAI_BUFFER_POOL_STAT_XOFF_ROOM_WATERMARK_BYTES on a pool where it is not supported (#1857)" (#1945)"

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -23,6 +23,16 @@ extern sai_object_id_t gSwitchId;
 
 static const vector<sai_buffer_pool_stat_t> bufferPoolWatermarkStatIds =
 {
+    SAI_BUFFER_POOL_STAT_WATERMARK_BYTES
+};
+
+static const vector<sai_buffer_pool_stat_t> bufferSharedHeadroomPoolWatermarkStatIds =
+{
+    SAI_BUFFER_POOL_STAT_XOFF_ROOM_WATERMARK_BYTES
+};
+
+static const vector<sai_buffer_pool_stat_t> bufferPoolAllWatermarkStatIds =
+{
     SAI_BUFFER_POOL_STAT_WATERMARK_BYTES,
     SAI_BUFFER_POOL_STAT_XOFF_ROOM_WATERMARK_BYTES
 };
@@ -233,29 +243,60 @@ void BufferOrch::generateBufferPoolWatermarkCounterIdList(void)
     }
 
     // Detokenize the SAI watermark stats to a string, separated by comma
-    string statList;
+    string statListBufferPoolOnly;
     for (const auto &it : bufferPoolWatermarkStatIds)
     {
-        statList += (sai_serialize_buffer_pool_stat(it) + list_item_delimiter);
+        statListBufferPoolOnly += (sai_serialize_buffer_pool_stat(it) + list_item_delimiter);
     }
-    if (!statList.empty())
+    string statListBufferPoolAndSharedHeadroomPool = statListBufferPoolOnly;
+    for (const auto &it : bufferSharedHeadroomPoolWatermarkStatIds)
     {
-        statList.pop_back();
+        statListBufferPoolAndSharedHeadroomPool += (sai_serialize_buffer_pool_stat(it) + list_item_delimiter);
+    }
+    if (!statListBufferPoolOnly.empty())
+    {
+        statListBufferPoolOnly.pop_back();
+    }
+    if (!statListBufferPoolAndSharedHeadroomPool.empty())
+    {
+        statListBufferPoolAndSharedHeadroomPool.pop_back();
     }
 
     // Some platforms do not support buffer pool watermark clear operation on a particular pool
     // Invoke the SAI clear_stats API per pool to query the capability from the API call return status
+    // Some platforms do not support shared headroom pool watermark read operation on a particular pool
+    // Invoke the SAI get_buffer_pool_stats API per pool to query the capability from the API call return status.
     // We use bit mask to mark the clear watermark capability of each buffer pool. We use an unsigned int to place hold
     // these bits. This assumes the total number of buffer pools to be no greater than 32, which should satisfy all use cases.
     unsigned int noWmClrCapability = 0;
+    unsigned int noSharedHeadroomPoolWmRdCapability = 0;
     unsigned int bitMask = 1;
+    uint32_t size = static_cast<uint32_t>(bufferSharedHeadroomPoolWatermarkStatIds.size());
+    vector<uint64_t> counterData(size);
     for (const auto &it : *(m_buffer_type_maps[APP_BUFFER_POOL_TABLE_NAME]))
     {
-        sai_status_t status = sai_buffer_api->clear_buffer_pool_stats(
+        sai_status_t status;
+        // Check whether shared headroom pool water mark is supported
+        status = sai_buffer_api->get_buffer_pool_stats(
                 it.second.m_saiObjectId,
-                static_cast<uint32_t>(bufferPoolWatermarkStatIds.size()),
-                reinterpret_cast<const sai_stat_id_t *>(bufferPoolWatermarkStatIds.data()));
-        if (status ==  SAI_STATUS_NOT_SUPPORTED || status == SAI_STATUS_NOT_IMPLEMENTED)
+                size,
+                reinterpret_cast<const sai_stat_id_t *>(bufferSharedHeadroomPoolWatermarkStatIds.data()),
+                counterData.data());
+        if (SAI_STATUS_IS_ATTR_NOT_SUPPORTED(status) || SAI_STATUS_IS_ATTR_NOT_IMPLEMENTED(status)
+            || status == SAI_STATUS_NOT_SUPPORTED || status == SAI_STATUS_NOT_IMPLEMENTED)
+        {
+            SWSS_LOG_NOTICE("Read shared headroom pool watermark failed on %s, rv: %s", it.first.c_str(), sai_serialize_status(status).c_str());
+            noSharedHeadroomPoolWmRdCapability |= bitMask;
+        }
+
+        const auto &watermarkStatIds = (noSharedHeadroomPoolWmRdCapability & bitMask) ? bufferPoolWatermarkStatIds : bufferPoolAllWatermarkStatIds;
+
+        status = sai_buffer_api->clear_buffer_pool_stats(
+                it.second.m_saiObjectId,
+                static_cast<uint32_t>(watermarkStatIds.size()),
+                reinterpret_cast<const sai_stat_id_t *>(watermarkStatIds.data()));
+        if (SAI_STATUS_IS_ATTR_NOT_SUPPORTED(status) || SAI_STATUS_IS_ATTR_NOT_IMPLEMENTED(status)
+            || status == SAI_STATUS_NOT_SUPPORTED || status == SAI_STATUS_NOT_IMPLEMENTED)
         {
             SWSS_LOG_NOTICE("Clear watermark failed on %s, rv: %s", it.first.c_str(), sai_serialize_status(status).c_str());
             noWmClrCapability |= bitMask;
@@ -274,11 +315,21 @@ void BufferOrch::generateBufferPoolWatermarkCounterIdList(void)
 
     // Push buffer pool watermark COUNTER_ID_LIST to FLEX_COUNTER_TABLE on a per buffer pool basis
     vector<FieldValueTuple> fvTuples;
-    fvTuples.emplace_back(BUFFER_POOL_COUNTER_ID_LIST, statList);
+
     bitMask = 1;
     for (const auto &it : *(m_buffer_type_maps[APP_BUFFER_POOL_TABLE_NAME]))
     {
         string key = BUFFER_POOL_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP ":" + sai_serialize_object_id(it.second.m_saiObjectId);
+        fvTuples.clear();
+
+        if (noSharedHeadroomPoolWmRdCapability & bitMask)
+        {
+            fvTuples.emplace_back(BUFFER_POOL_COUNTER_ID_LIST, statListBufferPoolOnly);
+        }
+        else
+        {
+            fvTuples.emplace_back(BUFFER_POOL_COUNTER_ID_LIST, statListBufferPoolAndSharedHeadroomPool);
+        }
 
         if (noWmClrCapability)
         {
@@ -288,15 +339,11 @@ void BufferOrch::generateBufferPoolWatermarkCounterIdList(void)
                 stats_mode = STATS_MODE_READ;
             }
             fvTuples.emplace_back(STATS_MODE_FIELD, stats_mode);
+        }
 
-            m_flexCounterTable->set(key, fvTuples);
-            fvTuples.pop_back();
-            bitMask <<= 1;
-        }
-        else
-        {
-            m_flexCounterTable->set(key, fvTuples);
-        }
+        m_flexCounterTable->set(key, fvTuples);
+
+        bitMask <<= 1;
     }
 
     m_isBufferPoolWatermarkCounterIdListGenerated = true;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Reverts Azure/sonic-swss 1945 which reverted PR 1857 
PR 1857 was introduced to avoid some error messages on some platforms. However, it made issue Azure/sonic-sairedis 862 more likely to be reproduced and has been reverted.
Now that the issue has been fixed by 1987, we can merge the PR.

Signed-off-by: Stephen Sun stephens@nvidia.com

**Why I did it**

**How I verified it**

**Details if related**
