### PR TITLE
Use abort instead of exit in case calling SAI API failure

### DIFF
--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -847,7 +847,7 @@ task_process_status Orch::handleSaiCreateStatus(sai_api_t api, sai_status_t stat
                 default:
                     SWSS_LOG_ERROR("Encountered failure in create operation, exiting orchagent, SAI API: %s, status: %s",
                                 sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());
-                    exit(EXIT_FAILURE);
+                    abort();
             }
             break;
         case SAI_API_HOSTIF:
@@ -865,7 +865,7 @@ task_process_status Orch::handleSaiCreateStatus(sai_api_t api, sai_status_t stat
                 default:
                     SWSS_LOG_ERROR("Encountered failure in create operation, exiting orchagent, SAI API: %s, status: %s",
                                 sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());
-                    exit(EXIT_FAILURE);
+                    abort();
             }
         default:
             switch (status)
@@ -876,7 +876,7 @@ task_process_status Orch::handleSaiCreateStatus(sai_api_t api, sai_status_t stat
                 default:
                     SWSS_LOG_ERROR("Encountered failure in create operation, exiting orchagent, SAI API: %s, status: %s",
                                 sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());
-                    exit(EXIT_FAILURE);
+                    abort();
             }
     }
     return task_need_retry;
@@ -917,12 +917,12 @@ task_process_status Orch::handleSaiSetStatus(sai_api_t api, sai_status_t status,
                 default:
                     SWSS_LOG_ERROR("Encountered failure in set operation, exiting orchagent, SAI API: %s, status: %s",
                             sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());
-                    exit(EXIT_FAILURE);
+                    abort();
             }
         default:
             SWSS_LOG_ERROR("Encountered failure in set operation, exiting orchagent, SAI API: %s, status: %s",
                         sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());
-            exit(EXIT_FAILURE);
+            abort();
     }
 
     return task_need_retry;
@@ -950,7 +950,7 @@ task_process_status Orch::handleSaiRemoveStatus(sai_api_t api, sai_status_t stat
         default:
             SWSS_LOG_ERROR("Encountered failure in remove operation, exiting orchagent, SAI API: %s, status: %s",
                         sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());
-            exit(EXIT_FAILURE);
+            abort();
     }
     return task_need_retry;
 }

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -633,7 +633,7 @@ void OrchDaemon::flush()
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to flush redis pipeline %d", status);
-        exit(EXIT_FAILURE);
+        abort();
     }
 
     // check if logroate is requested


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Use `abort` instead of `exit` in case calling SAI API failure
Currently, `exit` is used in functions `handleSai{Create,Remove,Set,Get}Status` on SAI failure while `abort` is used in some other functions on SAI failure.
IMO using `abort` yields benefits:
- consistent behavior in orchagent on SAI failure
- in mocked test, in case SAI failure occurs the test process will just exit silently, which makes it very difficult for developers to find out what happened. by using `abort`, a coredump will be generated, which helps developers nail down the issue.

So we would like to use `abort` in all cases of receiving SAI failure.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

**Why I did it**

**How I verified it**

Manually test.

**Details if related**
