### PR TITLE
Fix pfcwd

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -342,7 +342,7 @@ void BufferOrch::unlockZeroBufferPool(bool ingress)
         }
     }
 
-    if (pool)
+    if (pool != SAI_NULL_OBJECT_ID)
     {
         auto sai_status = sai_buffer_api->remove_buffer_pool(pool);
         if (SAI_STATUS_SUCCESS != sai_status)

--- a/orchagent/bufferorch.h
+++ b/orchagent/bufferorch.h
@@ -37,6 +37,7 @@ public:
     static type_map m_buffer_type_maps;
     void generateBufferPoolWatermarkCounterIdList(void);
     const object_reference_map &getBufferPoolNameOidMap(void);
+    sai_object_id_t getBufferPoolId(bool direction) const;
 
 private:
     typedef task_process_status (BufferOrch::*buffer_table_handler)(KeyOpFieldsValuesTuple &tuple);
@@ -71,6 +72,9 @@ private:
     unique_ptr<DBConnector> m_countersDb;
 
     bool m_isBufferPoolWatermarkCounterIdListGenerated = false;
+
+    std::set<sai_object_id_t> m_ingressBufferPools;
+    std::set<sai_object_id_t> m_egressBufferPools;
 };
 #endif /* SWSS_BUFFORCH_H */
 

--- a/orchagent/bufferorch.h
+++ b/orchagent/bufferorch.h
@@ -37,14 +37,14 @@ public:
     static type_map m_buffer_type_maps;
     void generateBufferPoolWatermarkCounterIdList(void);
     const object_reference_map &getBufferPoolNameOidMap(void);
-    sai_object_id_t& getZeroBufferProfile(bool ingress)
+    sai_object_id_t getZeroBufferPool(bool ingress)
     {
-        return ingress ? m_ingressZeroBufferProfile : m_egressZeroBufferProfile;
+        return ingress ? m_ingressZeroBufferPool : m_egressZeroBufferPool;
     }
 
-    void lockZeroBufferProfile(bool ingress);
-    void unlockZeroBufferProfile(bool ingress);
-    void setZeroBufferProfileAndPool(bool direction, sai_object_id_t pool, sai_object_id_t profile);
+    void lockZeroBufferPool(bool ingress);
+    void unlockZeroBufferPool(bool ingress);
+    void setZeroBufferPool(bool direction, sai_object_id_t pool);
 
 private:
     typedef task_process_status (BufferOrch::*buffer_table_handler)(KeyOpFieldsValuesTuple &tuple);
@@ -81,11 +81,9 @@ private:
     bool m_isBufferPoolWatermarkCounterIdListGenerated = false;
 
     sai_object_id_t m_ingressZeroBufferPool;
-    sai_object_id_t m_ingressZeroBufferProfile;
     sai_object_id_t m_egressZeroBufferPool;
-    sai_object_id_t m_egressZeroBufferProfile;
-    sai_object_id_t m_ingressZeroPoolRefCount;
-    sai_object_id_t m_egressZeroPoolRefCount;
+    int m_ingressZeroPoolRefCount;
+    int m_egressZeroPoolRefCount;
 };
 #endif /* SWSS_BUFFORCH_H */
 

--- a/orchagent/bufferorch.h
+++ b/orchagent/bufferorch.h
@@ -37,7 +37,14 @@ public:
     static type_map m_buffer_type_maps;
     void generateBufferPoolWatermarkCounterIdList(void);
     const object_reference_map &getBufferPoolNameOidMap(void);
-    sai_object_id_t getBufferPoolId(bool direction) const;
+    sai_object_id_t& getZeroBufferProfile(bool ingress)
+    {
+        return ingress ? m_ingressZeroBufferProfile : m_egressZeroBufferProfile;
+    }
+
+    void lockZeroBufferProfile(bool ingress);
+    void unlockZeroBufferProfile(bool ingress);
+    void setZeroBufferProfileAndPool(bool direction, sai_object_id_t pool, sai_object_id_t profile);
 
 private:
     typedef task_process_status (BufferOrch::*buffer_table_handler)(KeyOpFieldsValuesTuple &tuple);
@@ -73,8 +80,12 @@ private:
 
     bool m_isBufferPoolWatermarkCounterIdListGenerated = false;
 
-    std::set<sai_object_id_t> m_ingressBufferPools;
-    std::set<sai_object_id_t> m_egressBufferPools;
+    sai_object_id_t m_ingressZeroBufferPool;
+    sai_object_id_t m_ingressZeroBufferProfile;
+    sai_object_id_t m_egressZeroBufferPool;
+    sai_object_id_t m_egressZeroBufferProfile;
+    sai_object_id_t m_ingressZeroPoolRefCount;
+    sai_object_id_t m_egressZeroPoolRefCount;
 };
 #endif /* SWSS_BUFFORCH_H */
 

--- a/orchagent/pfcactionhandler.cpp
+++ b/orchagent/pfcactionhandler.cpp
@@ -717,6 +717,20 @@ PfcWdZeroBufferHandler::ZeroBufferProfile &PfcWdZeroBufferHandler::ZeroBufferPro
     return instance;
 }
 
+sai_object_id_t& PfcWdZeroBufferHandler::ZeroBufferProfile::getProfile(bool ingress)
+{
+    auto &profileId = ingress ? m_zeroIngressBufferProfile : m_zeroEgressBufferProfile;
+    if (profileId == SAI_NULL_OBJECT_ID)
+    {
+        profileId = gBufferOrch->getZeroBufferProfile(ingress);
+        if (profileId != SAI_NULL_OBJECT_ID)
+        {
+            gBufferOrch->lockZeroBufferProfile(ingress);
+        }
+    }
+    return profileId;
+}
+
 sai_object_id_t PfcWdZeroBufferHandler::ZeroBufferProfile::getZeroBufferProfile(bool ingress)
 {
     SWSS_LOG_ENTER();
@@ -736,37 +750,29 @@ void PfcWdZeroBufferHandler::ZeroBufferProfile::createZeroBufferProfile(bool ing
     sai_attribute_t attr;
     vector<sai_attribute_t> attribs;
     sai_status_t status;
-    auto &poolId = getPool(ingress);
 
-    poolId = gBufferOrch->getBufferPoolId(ingress);
+    // Create zero pool
+    attr.id = SAI_BUFFER_POOL_ATTR_SIZE;
+    attr.value.u64 = 0;
+    attribs.push_back(attr);
 
-    if (poolId == SAI_NULL_OBJECT_ID)
+    attr.id = SAI_BUFFER_POOL_ATTR_TYPE;
+    attr.value.u32 = ingress ? SAI_BUFFER_POOL_TYPE_INGRESS : SAI_BUFFER_POOL_TYPE_EGRESS;
+    attribs.push_back(attr);
+
+    attr.id = SAI_BUFFER_POOL_ATTR_THRESHOLD_MODE;
+    attr.value.u32 = SAI_BUFFER_POOL_THRESHOLD_MODE_DYNAMIC;
+    attribs.push_back(attr);
+
+    status = sai_buffer_api->create_buffer_pool(
+        &getPool(ingress),
+        gSwitchId,
+        static_cast<uint32_t>(attribs.size()),
+        attribs.data());
+    if (status != SAI_STATUS_SUCCESS)
     {
-        // Create zero pool
-        attr.id = SAI_BUFFER_POOL_ATTR_SIZE;
-        attr.value.u64 = 0;
-        attribs.push_back(attr);
-
-        attr.id = SAI_BUFFER_POOL_ATTR_TYPE;
-        attr.value.u32 = ingress ? SAI_BUFFER_POOL_TYPE_INGRESS : SAI_BUFFER_POOL_TYPE_EGRESS;
-        attribs.push_back(attr);
-
-        attr.id = SAI_BUFFER_POOL_ATTR_THRESHOLD_MODE;
-        attr.value.u32 = SAI_BUFFER_POOL_THRESHOLD_MODE_DYNAMIC;
-        attribs.push_back(attr);
-
-        status = sai_buffer_api->create_buffer_pool(
-            &poolId,
-            gSwitchId,
-            static_cast<uint32_t>(attribs.size()),
-            attribs.data());
-        if (status != SAI_STATUS_SUCCESS)
-        {
-            SWSS_LOG_ERROR("Failed to create dynamic zero buffer pool for PFC WD: %d", status);
-            return;
-        }
-
-        m_hasCreatedPool = true;
+        SWSS_LOG_ERROR("Failed to create dynamic zero buffer pool for PFC WD: %d", status);
+        return;
     }
 
     // Create zero profile
@@ -798,25 +804,15 @@ void PfcWdZeroBufferHandler::ZeroBufferProfile::createZeroBufferProfile(bool ing
         SWSS_LOG_ERROR("Failed to create dynamic zero buffer profile for PFC WD: %d", status);
         return;
     }
+
+    // Pass the ownership to BufferOrch
+    gBufferOrch->setZeroBufferProfileAndPool(ingress, getPool(ingress), getProfile(ingress));
+    gBufferOrch->lockZeroBufferProfile(ingress);
 }
 
 void PfcWdZeroBufferHandler::ZeroBufferProfile::destroyZeroBufferProfile(bool ingress)
 {
     SWSS_LOG_ENTER();
 
-    sai_status_t status = sai_buffer_api->remove_buffer_profile(getProfile(ingress));
-    if (status != SAI_STATUS_SUCCESS)
-    {
-        SWSS_LOG_ERROR("Failed to remove static zero buffer profile for PFC WD: %d", status);
-        return;
-    }
-
-    if (m_hasCreatedPool)
-    {
-        status = sai_buffer_api->remove_buffer_pool(getPool(ingress));
-        if (status != SAI_STATUS_SUCCESS)
-        {
-            SWSS_LOG_ERROR("Failed to remove static zero buffer pool for PFC WD: %d", status);
-        }
-    }
+    gBufferOrch->unlockZeroBufferProfile(ingress);
 }

--- a/orchagent/pfcactionhandler.cpp
+++ b/orchagent/pfcactionhandler.cpp
@@ -824,7 +824,7 @@ void PfcWdZeroBufferHandler::ZeroBufferProfile::destroyZeroBufferProfile(bool in
 {
     SWSS_LOG_ENTER();
 
-    if (sai_buffer_api != NULL)
+    if (getProfile(ingress) != SAI_NULL_OBJECT_ID)
     {
         sai_status_t status = sai_buffer_api->remove_buffer_profile(getProfile(ingress));
         if (status != SAI_STATUS_SUCCESS)
@@ -832,7 +832,11 @@ void PfcWdZeroBufferHandler::ZeroBufferProfile::destroyZeroBufferProfile(bool in
             SWSS_LOG_ERROR("Failed to remove static zero buffer profile for PFC WD: %d", status);
             return;
         }
+    }
 
+    auto &pool = ingress ? m_zeroIngressBufferPool : m_zeroEgressBufferPool;
+    if (pool != SAI_NULL_OBJECT_ID)
+    {
         gBufferOrch->unlockZeroBufferPool(ingress);
     }
 }

--- a/orchagent/pfcactionhandler.cpp
+++ b/orchagent/pfcactionhandler.cpp
@@ -719,6 +719,11 @@ PfcWdZeroBufferHandler::ZeroBufferProfile &PfcWdZeroBufferHandler::ZeroBufferPro
 
 sai_object_id_t& PfcWdZeroBufferHandler::ZeroBufferProfile::getPool(bool ingress)
 {
+    // If there is a cached zero buffer pool, just use it
+    // else fetch zero buffer pool from buffer orch
+    // If there is one, use it and increase the reference number.
+    // otherwise, just return NULL OID
+    // PfcWdZeroBufferHandler will create it later and notify buffer orch later
     auto &poolId = ingress ? m_zeroIngressBufferPool : m_zeroEgressBufferPool;
     if (poolId == SAI_NULL_OBJECT_ID)
     {

--- a/orchagent/pfcactionhandler.h
+++ b/orchagent/pfcactionhandler.h
@@ -157,6 +157,8 @@ class PfcWdZeroBufferHandler: public PfcWdLossyHandler
                 sai_object_id_t m_zeroEgressBufferPool = SAI_NULL_OBJECT_ID;
                 sai_object_id_t m_zeroIngressBufferProfile = SAI_NULL_OBJECT_ID;
                 sai_object_id_t m_zeroEgressBufferProfile = SAI_NULL_OBJECT_ID;
+
+                bool m_hasCreatedPool;
         };
 
         sai_object_id_t m_originalQueueBufferProfile = SAI_NULL_OBJECT_ID;

--- a/orchagent/pfcactionhandler.h
+++ b/orchagent/pfcactionhandler.h
@@ -143,10 +143,10 @@ class PfcWdZeroBufferHandler: public PfcWdLossyHandler
                 void createZeroBufferProfile(bool ingress);
                 void destroyZeroBufferProfile(bool ingress);
 
-                sai_object_id_t& getProfile(bool ingress)
-                {
+                sai_object_id_t& getProfile(bool ingress);
+                /*                {
                     return ingress ? m_zeroIngressBufferProfile : m_zeroEgressBufferProfile;
-                }
+                    }*/
 
                 sai_object_id_t& getPool(bool ingress)
                 {

--- a/orchagent/pfcactionhandler.h
+++ b/orchagent/pfcactionhandler.h
@@ -143,22 +143,17 @@ class PfcWdZeroBufferHandler: public PfcWdLossyHandler
                 void createZeroBufferProfile(bool ingress);
                 void destroyZeroBufferProfile(bool ingress);
 
-                sai_object_id_t& getProfile(bool ingress);
-                /*                {
-                    return ingress ? m_zeroIngressBufferProfile : m_zeroEgressBufferProfile;
-                    }*/
-
-                sai_object_id_t& getPool(bool ingress)
+                sai_object_id_t& getProfile(bool ingress)
                 {
-                    return ingress ? m_zeroIngressBufferPool : m_zeroEgressBufferPool;
+                    return ingress ? m_zeroIngressBufferProfile : m_zeroEgressBufferProfile;
                 }
+
+                sai_object_id_t& getPool(bool ingress);
 
                 sai_object_id_t m_zeroIngressBufferPool = SAI_NULL_OBJECT_ID;
                 sai_object_id_t m_zeroEgressBufferPool = SAI_NULL_OBJECT_ID;
                 sai_object_id_t m_zeroIngressBufferProfile = SAI_NULL_OBJECT_ID;
                 sai_object_id_t m_zeroEgressBufferProfile = SAI_NULL_OBJECT_ID;
-
-                bool m_hasCreatedPool;
         };
 
         sai_object_id_t m_originalQueueBufferProfile = SAI_NULL_OBJECT_ID;

--- a/tests/mock_tests/mock_orchagent_main.h
+++ b/tests/mock_tests/mock_orchagent_main.h
@@ -9,7 +9,9 @@
 #include "neighorch.h"
 #include "fdborch.h"
 #include "mirrororch.h"
+#define private public
 #include "bufferorch.h"
+#undef private
 #include "vrforch.h"
 #include "vnetorch.h"
 #include "vxlanorch.h"

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -7,7 +7,9 @@
 #include "mock_orchagent_main.h"
 #include "mock_table.h"
 #include "notifier.h"
+#define private public
 #include "pfcactionhandler.h"
+#undef private
 
 #include <sstream>
 
@@ -17,6 +19,105 @@ namespace portsorch_test
 {
 
     using namespace std;
+
+    sai_queue_api_t ut_sai_queue_api;
+    sai_queue_api_t *pold_sai_queue_api;
+    sai_buffer_api_t ut_sai_buffer_api;
+    sai_buffer_api_t *pold_sai_buffer_api;
+
+    string _ut_stub_queue_key;
+    sai_status_t _ut_stub_sai_get_queue_attribute(
+        _In_ sai_object_id_t queue_id,
+        _In_ uint32_t attr_count,
+        _Inout_ sai_attribute_t *attr_list)
+    {
+        if (attr_count == 1 && attr_list[0].id == SAI_QUEUE_ATTR_BUFFER_PROFILE_ID)
+        {
+            auto &typemapQueue = (*gBufferOrch->m_buffer_type_maps[APP_BUFFER_QUEUE_TABLE_NAME]);
+            auto &profileName = typemapQueue["Ethernet0:3-4"].m_objsReferencingByMe["profile"];
+            auto profileNameVec = tokenize(profileName, ':');
+            auto &typemapProfile = (*gBufferOrch->m_buffer_type_maps[APP_BUFFER_PROFILE_TABLE_NAME]);
+            attr_list[0].value.oid = typemapProfile[profileNameVec[1]].m_saiObjectId;
+            return SAI_STATUS_SUCCESS;
+        }
+        else
+        {
+            return pold_sai_queue_api->get_queue_attribute(queue_id, attr_count, attr_list);
+        }
+    }
+
+    sai_status_t _ut_stub_sai_get_ingress_priority_group_attribute(
+        _In_ sai_object_id_t ingress_priority_group_id,
+        _In_ uint32_t attr_count,
+        _Inout_ sai_attribute_t *attr_list)
+    {
+        if (attr_count == 1 && attr_list[0].id == SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE)
+        {
+            auto &typemapPg = (*gBufferOrch->m_buffer_type_maps[APP_BUFFER_PG_TABLE_NAME]);
+            auto &profileName = typemapPg["Ethernet0:3-4"].m_objsReferencingByMe["profile"];
+            auto profileNameVec = tokenize(profileName, ':');
+            auto &typemapProfile = (*gBufferOrch->m_buffer_type_maps[APP_BUFFER_PROFILE_TABLE_NAME]);
+            attr_list[0].value.oid = typemapProfile[profileNameVec[1]].m_saiObjectId;
+            return SAI_STATUS_SUCCESS;
+        }
+        else
+        {
+            return pold_sai_buffer_api->get_ingress_priority_group_attribute(ingress_priority_group_id, attr_count, attr_list);
+        }
+    }
+
+    int _sai_create_buffer_pool_count = 0;
+    sai_status_t _ut_stub_sai_create_buffer_pool(
+        _Out_ sai_object_id_t *buffer_pool_id,
+        _In_ sai_object_id_t switch_id,
+        _In_ uint32_t attr_count,
+        _In_ const sai_attribute_t *attr_list)
+    {
+        auto status = pold_sai_buffer_api->create_buffer_pool(buffer_pool_id, switch_id, attr_count, attr_list);
+        if (SAI_STATUS_SUCCESS == status)
+            _sai_create_buffer_pool_count++;
+        return status;
+    }
+
+    int _sai_remove_buffer_pool_count = 0;
+    sai_status_t _ut_stub_sai_remove_buffer_pool(
+        _In_ sai_object_id_t buffer_pool_id)
+    {
+        auto status = pold_sai_buffer_api->remove_buffer_pool(buffer_pool_id);
+        if (SAI_STATUS_SUCCESS == status)
+            _sai_remove_buffer_pool_count++;
+        return status;
+    }
+
+    void _hook_sai_buffer_and_queue_api()
+    {
+        ut_sai_buffer_api = *sai_buffer_api;
+        pold_sai_buffer_api = sai_buffer_api;
+        ut_sai_buffer_api.create_buffer_pool = _ut_stub_sai_create_buffer_pool;
+        ut_sai_buffer_api.remove_buffer_pool = _ut_stub_sai_remove_buffer_pool;
+        ut_sai_buffer_api.get_ingress_priority_group_attribute = _ut_stub_sai_get_ingress_priority_group_attribute;
+        sai_buffer_api = &ut_sai_buffer_api;
+
+        ut_sai_queue_api = *sai_queue_api;
+        pold_sai_queue_api = sai_queue_api;
+        ut_sai_queue_api.get_queue_attribute = _ut_stub_sai_get_queue_attribute;
+        sai_queue_api = &ut_sai_queue_api;
+    }
+
+    void _unhook_sai_buffer_and_queue_api()
+    {
+        sai_buffer_api = pold_sai_buffer_api;
+        sai_queue_api = pold_sai_queue_api;
+    }
+
+    void clear_pfcwd_zero_buffer_handler()
+    {
+        auto &zeroProfile = PfcWdZeroBufferHandler::ZeroBufferProfile::getInstance();        
+        zeroProfile.m_zeroIngressBufferPool = SAI_NULL_OBJECT_ID;
+        zeroProfile.m_zeroEgressBufferPool = SAI_NULL_OBJECT_ID;
+        zeroProfile.m_zeroIngressBufferProfile = SAI_NULL_OBJECT_ID;
+        zeroProfile.m_zeroEgressBufferProfile = SAI_NULL_OBJECT_ID;
+    }
 
     struct PortsOrchTest : public ::testing::Test
     {
@@ -355,10 +456,12 @@ namespace portsorch_test
 
     TEST_F(PortsOrchTest, PfcZeroBufferHandlerLocksPortPgAndQueue)
     {
+        _hook_sai_buffer_and_queue_api();
         Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
         Table pgTable = Table(m_app_db.get(), APP_BUFFER_PG_TABLE_NAME);
         Table profileTable = Table(m_app_db.get(), APP_BUFFER_PROFILE_TABLE_NAME);
         Table poolTable = Table(m_app_db.get(), APP_BUFFER_POOL_TABLE_NAME);
+        Table queueTable = Table(m_app_db.get(), APP_BUFFER_QUEUE_TABLE_NAME);
 
         // Get SAI default ports to populate DB
         auto ports = ut_helper::getInitialSaiPorts();
@@ -397,37 +500,68 @@ namespace portsorch_test
         Port port;
         gPortsOrch->getPort("Ethernet0", port);
 
-        auto countersTable = make_shared<Table>(m_counters_db.get(), COUNTERS_TABLE);
-        auto dropHandler = make_unique<PfcWdZeroBufferHandler>(port.m_port_id, port.m_queue_ids[3], 3, countersTable);
-
         // Create test buffer pool
         poolTable.set(
-            "test_pool",
+            "ingress_pool",
             {
                 { "type", "ingress" },
                 { "mode", "dynamic" },
                 { "size", "4200000" },
             });
+        poolTable.set(
+            "egress_pool",
+            {
+                { "type", "egress" },
+                { "mode", "dynamic" },
+                { "size", "4200000" },
+            });
 
         // Create test buffer profile
-        profileTable.set("test_profile", { { "pool", "test_pool" },
+        profileTable.set("test_profile", { { "pool", "ingress_pool" },
                                            { "xon", "14832" },
                                            { "xoff", "14832" },
                                            { "size", "35000" },
                                            { "dynamic_th", "0" } });
+        profileTable.set("ingress_profile", { { "pool", "ingress_pool" },
+                                              { "xon", "14832" },
+                                              { "xoff", "14832" },
+                                              { "size", "35000" },
+                                              { "dynamic_th", "0" } });
+        profileTable.set("egress_profile", { { "pool", "egress_pool" },
+                                             { "size", "0" },
+                                             { "dynamic_th", "0" } });
 
         // Apply profile on PGs 3-4 all ports
         for (const auto &it : ports)
         {
             std::ostringstream oss;
             oss << it.first << ":3-4";
-            pgTable.set(oss.str(), { { "profile", "test_profile" } });
+            pgTable.set(oss.str(), { { "profile", "ingress_profile" } });
+            queueTable.set(oss.str(), { {"profile", "egress_profile" } });
         }
         gBufferOrch->addExistingData(&pgTable);
         gBufferOrch->addExistingData(&poolTable);
         gBufferOrch->addExistingData(&profileTable);
+        gBufferOrch->addExistingData(&queueTable);
 
         // process pool, profile and PGs
+        static_cast<Orch *>(gBufferOrch)->doTask();
+
+        auto countersTable = make_shared<Table>(m_counters_db.get(), COUNTERS_TABLE);
+        auto current_create_buffer_pool_count = _sai_create_buffer_pool_count;
+        auto dropHandler = make_unique<PfcWdZeroBufferHandler>(port.m_port_id, port.m_queue_ids[3], 3, countersTable);
+
+        current_create_buffer_pool_count += 2;
+        ASSERT_TRUE(current_create_buffer_pool_count == _sai_create_buffer_pool_count);
+        ASSERT_TRUE(PfcWdZeroBufferHandler::ZeroBufferProfile::getInstance().getPool(true) == gBufferOrch->m_ingressZeroBufferPool);
+        ASSERT_TRUE(PfcWdZeroBufferHandler::ZeroBufferProfile::getInstance().getPool(false) == gBufferOrch->m_egressZeroBufferPool);
+        ASSERT_TRUE(gBufferOrch->m_ingressZeroPoolRefCount == 1);
+        ASSERT_TRUE(gBufferOrch->m_egressZeroPoolRefCount == 1);
+
+        std::deque<KeyOpFieldsValuesTuple> entries;
+        entries.push_back({"Ethernet0:3-4", "SET", {{ "profile", "test_profile"}}});
+        auto pgConsumer = static_cast<Consumer*>(gBufferOrch->getExecutor(APP_BUFFER_PG_TABLE_NAME));
+        pgConsumer->addToSync(entries);
         static_cast<Orch *>(gBufferOrch)->doTask();
 
         // Port should have been updated by BufferOrch->doTask
@@ -437,10 +571,29 @@ namespace portsorch_test
         ASSERT_TRUE(port.m_priority_group_pending_profile[3] == profile_id);
         ASSERT_TRUE(port.m_priority_group_pending_profile[4] == SAI_NULL_OBJECT_ID);
 
-        auto pgConsumer = static_cast<Consumer*>(gBufferOrch->getExecutor(APP_BUFFER_PG_TABLE_NAME));
+        pgConsumer = static_cast<Consumer*>(gBufferOrch->getExecutor(APP_BUFFER_PG_TABLE_NAME));
         pgConsumer->dumpPendingTasks(ts);
         ASSERT_TRUE(ts.empty()); // PG is stored in m_priority_group_pending_profile
         ts.clear();
+
+        // Create a zero buffer pool after PFC storm
+        entries.push_back({"ingress_zero_pool", "SET", {{ "type", "ingress" },
+                                                        { "mode", "static" },
+                                                        { "size", "0" }}});
+        auto poolConsumer = static_cast<Consumer*>(gBufferOrch->getExecutor(APP_BUFFER_POOL_TABLE_NAME));
+        poolConsumer->addToSync(entries);
+        static_cast<Orch *>(gBufferOrch)->doTask();
+        // Reference increased
+        ASSERT_TRUE(gBufferOrch->m_ingressZeroPoolRefCount == 2);
+        // Didn't create buffer pool again
+        ASSERT_TRUE(_sai_create_buffer_pool_count == current_create_buffer_pool_count);
+
+        entries.push_back({"ingress_zero_pool", "DEL", {}});
+        poolConsumer->addToSync(entries);
+        auto current_remove_buffer_pool_count = _sai_remove_buffer_pool_count;
+        static_cast<Orch *>(gBufferOrch)->doTask();
+        ASSERT_TRUE(gBufferOrch->m_ingressZeroPoolRefCount == 1);
+        ASSERT_TRUE(_sai_remove_buffer_pool_count == current_remove_buffer_pool_count);
 
         // release zero buffer drop handler
         dropHandler.reset();
@@ -459,6 +612,133 @@ namespace portsorch_test
         pgConsumer->dumpPendingTasks(ts);
         ASSERT_TRUE(ts.empty()); // PG should be processed now
         ts.clear();
+        clear_pfcwd_zero_buffer_handler();
+        _unhook_sai_buffer_and_queue_api();
+    }
+
+    TEST_F(PortsOrchTest, PfcZeroBufferHandlerLocksPortWithZeroPoolCreated)
+    {
+        _hook_sai_buffer_and_queue_api();
+        Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+        Table pgTable = Table(m_app_db.get(), APP_BUFFER_PG_TABLE_NAME);
+        Table profileTable = Table(m_app_db.get(), APP_BUFFER_PROFILE_TABLE_NAME);
+        Table poolTable = Table(m_app_db.get(), APP_BUFFER_POOL_TABLE_NAME);
+        Table queueTable = Table(m_app_db.get(), APP_BUFFER_QUEUE_TABLE_NAME);
+
+        // Get SAI default ports to populate DB
+        auto ports = ut_helper::getInitialSaiPorts();
+
+        // Populate port table with SAI ports
+        for (const auto &it : ports)
+        {
+            portTable.set(it.first, it.second);
+        }
+
+        // Set PortConfigDone, PortInitDone
+        portTable.set("PortConfigDone", { { "count", to_string(ports.size()) } });
+        portTable.set("PortInitDone", { { "lanes", "0" } });
+
+        // refill consumer
+        gPortsOrch->addExistingData(&portTable);
+
+        // Apply configuration :
+        //  create ports
+
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        // Apply configuration
+        //          ports
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        ASSERT_TRUE(gPortsOrch->allPortsReady());
+
+        // No more tasks
+        vector<string> ts;
+        gPortsOrch->dumpPendingTasks(ts);
+        ASSERT_TRUE(ts.empty());
+        ts.clear();
+
+        // Simulate storm drop handler started on Ethernet0 TC 3
+        Port port;
+        gPortsOrch->getPort("Ethernet0", port);
+
+        // Create test buffer pool
+        poolTable.set(
+            "ingress_pool",
+            {
+                { "type", "ingress" },
+                { "mode", "dynamic" },
+                { "size", "4200000" },
+            });
+        poolTable.set(
+            "egress_pool",
+            {
+                { "type", "egress" },
+                { "mode", "dynamic" },
+                { "size", "4200000" },
+            });
+        poolTable.set("zeropool",
+                      {
+                          { "type", "ingress" },
+                          { "mode", "static" },
+                          { "size", "0" }
+                      });
+        auto poolConsumer = static_cast<Consumer*>(gBufferOrch->getExecutor(APP_BUFFER_POOL_TABLE_NAME));
+
+        // Create test buffer profile
+        profileTable.set("test_profile", { { "pool", "ingress_pool" },
+                                           { "xon", "14832" },
+                                           { "xoff", "14832" },
+                                           { "size", "35000" },
+                                           { "dynamic_th", "0" } });
+        profileTable.set("ingress_profile", { { "pool", "ingress_pool" },
+                                              { "xon", "14832" },
+                                              { "xoff", "14832" },
+                                              { "size", "35000" },
+                                              { "dynamic_th", "0" } });
+        profileTable.set("egress_profile", { { "pool", "egress_pool" },
+                                             { "size", "0" },
+                                             { "dynamic_th", "0" } });
+
+        // Apply profile on PGs 3-4 all ports
+        for (const auto &it : ports)
+        {
+            std::ostringstream oss;
+            oss << it.first << ":3-4";
+            pgTable.set(oss.str(), { { "profile", "ingress_profile" } });
+            queueTable.set(oss.str(), { {"profile", "egress_profile" } });
+        }
+        gBufferOrch->addExistingData(&pgTable);
+        gBufferOrch->addExistingData(&poolTable);
+        gBufferOrch->addExistingData(&profileTable);
+        gBufferOrch->addExistingData(&queueTable);
+
+        // process pool, profile and PGs
+        static_cast<Orch *>(gBufferOrch)->doTask();
+
+        auto countersTable = make_shared<Table>(m_counters_db.get(), COUNTERS_TABLE);
+        auto current_create_buffer_pool_count = _sai_create_buffer_pool_count;
+        auto dropHandler = make_unique<PfcWdZeroBufferHandler>(port.m_port_id, port.m_queue_ids[3], 3, countersTable);
+
+        current_create_buffer_pool_count++; // Increased for egress zero pool
+        ASSERT_TRUE(current_create_buffer_pool_count == _sai_create_buffer_pool_count);
+        ASSERT_TRUE(PfcWdZeroBufferHandler::ZeroBufferProfile::getInstance().getPool(true) == gBufferOrch->m_ingressZeroBufferPool);
+        ASSERT_TRUE(PfcWdZeroBufferHandler::ZeroBufferProfile::getInstance().getPool(false) == gBufferOrch->m_egressZeroBufferPool);
+        ASSERT_TRUE(gBufferOrch->m_ingressZeroPoolRefCount == 2);
+        ASSERT_TRUE(gBufferOrch->m_egressZeroPoolRefCount == 1);
+
+        std::deque<KeyOpFieldsValuesTuple> entries;
+        entries.push_back({"ingress_zero_pool", "DEL", {}});
+        poolConsumer->addToSync(entries);
+        auto current_remove_buffer_pool_count = _sai_remove_buffer_pool_count;
+        static_cast<Orch *>(gBufferOrch)->doTask();
+        ASSERT_TRUE(gBufferOrch->m_ingressZeroPoolRefCount == 1);
+        ASSERT_TRUE(_sai_remove_buffer_pool_count == current_remove_buffer_pool_count);
+
+        // release zero buffer drop handler
+        dropHandler.reset();
+        clear_pfcwd_zero_buffer_handler();
+        _unhook_sai_buffer_and_queue_api();
     }
 
     /* This test checks that a LAG member validation happens on orchagent level


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Fix issue: sometimes PFC WD is unable to create zero buffer pool.
On some platforms, an ingress/egress zero buffer profile will be applied on the PG and queue which are under PFC storm. The zero buffer profile is created based on zero buffer pool. However, sometimes it fails to create zero buffer pool due to too many buffer pools existing in the system.
Sometimes, there is a zero buffer pool existing on the system for reclaiming buffer. In that case, we can leverage it to create zero buffer profile for PFC WD.

**Why I did it**

Fix the issue via sharing the zero buffer pool between PFC WD and buffer orchagent

**How I verified it**

Manually test
Run PFC WD test and PFC WD warm reboot test
Run unit test

**Details if related**
***The detailed flow is like this:***
PFC Storm detected:
1. If there is a zero pool in PFC WD's cache, just create the zero buffer profile based on it
2. Otherwise, fetching the zero pool from buffer orchagent
   - If got one, create the zero buffer profile based on it
   - Otherwise,
     - create a zero buffer pool
     - notify the zero buffer pool about the buffer orch
   - In both cases, PFC WD should notify buffer orch to increase the reference number of the zero buffer pool.

Buffer orchagent:
- When creating the zero buffer pool,
  - check whether there is one. if yes, skip the SAI API create_buffer_pool
  - increase the reference number.
- Before removing the zero buffer pool, decrease and check the reference number. if it is zero (after decreased), skip SAI API destroy_buffer_pool.
- When PFC WD decrease reference number: remove the zero buffer pool if the reference number becomes zero

***Notes***
We do not leverage the `object_reference_map` infrastructure to track the dependency because:
 - it assumes the dependency will eventually be removed if an object is removed. that's NOT true in this scenario because the PFC storm can last for a relatively long time and even cross warm reboot.
 - the interfaces differ.