### PR TITLE
[Bugfix] Remove redundant and problematic code to skip "pool" field in buffer profile handling

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -661,13 +661,6 @@ task_process_status BufferOrch::processBufferProfile(KeyOpFieldsValuesTuple &tup
             sai_attribute_t attr;
             if (field == buffer_pool_field_name)
             {
-                if (SAI_NULL_OBJECT_ID != sai_object)
-                {
-                    // We should skip the profile's pool name because it's create only when setting a profile's attribute.
-                    SWSS_LOG_INFO("Skip setting buffer profile's pool %s for profile %s", value.c_str(), object_name.c_str());
-                    continue;
-                }
-
                 sai_object_id_t sai_pool;
                 ref_resolve_status resolve_result = resolveFieldRefValue(m_buffer_type_maps, buffer_pool_field_name,
                                                     buffer_to_ref_table_map.at(buffer_pool_field_name),


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Remove redundant and problematic code to skip "pool" field in buffer profile handling

Signed-off-by: Stephen Sun <stephens@nvidia.com>

**Why I did it**
When a buffer profile is modified, the snippet of code skipped "pool" field handling without pool's name being parsed, which broke the dependency tracing logic.
In a rare scenario, if buffer orchagent receives a notification to remove the pool before removing the profile, it can cause the buffer pool to be removed when it is still referenced.

**How I verified it**
Manually and regression test.

**Details if related**
