### PR TITLE
[Bugfix][QosOrch] The notifications cannot be drained in QosOrch in case the first one needs to retry

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -2645,6 +2645,7 @@ void AclOrch::init(vector<TableConnector>& connectors, PortsOrch *portOrch, Mirr
     // Broadcom and Mellanox. Virtual switch is also supported for testing
     // purposes.
     string platform = getenv("platform") ? getenv("platform") : "";
+    string sub_platform = getenv("sub_platform") ? getenv("sub_platform") : "";
     if (platform == BRCM_PLATFORM_SUBSTRING ||
             platform == CISCO_8000_PLATFORM_SUBSTRING ||
             platform == MLNX_PLATFORM_SUBSTRING ||
@@ -2676,9 +2677,11 @@ void AclOrch::init(vector<TableConnector>& connectors, PortsOrch *portOrch, Mirr
             m_mirrorTableCapabilities[TABLE_TYPE_MIRRORV6] ? "yes" : "no");
 
     // In Mellanox platform, V4 and V6 rules are stored in different tables
+    // In Broadcom DNX platform also, V4 and V6 rules are stored in different tables
     if (platform == MLNX_PLATFORM_SUBSTRING ||
         platform == CISCO_8000_PLATFORM_SUBSTRING ||
-        platform == MRVL_PLATFORM_SUBSTRING)
+        platform == MRVL_PLATFORM_SUBSTRING ||
+        (platform == BRCM_PLATFORM_SUBSTRING && sub_platform == BRCM_DNX_PLATFORM_SUBSTRING))
     {
         m_isCombinedMirrorV6Table = false;
     }

--- a/orchagent/bfdorch.h
+++ b/orchagent/bfdorch.h
@@ -26,12 +26,15 @@ private:
     uint32_t bfd_gen_id(void);
     uint32_t bfd_src_port(void);
 
+    bool register_bfd_state_change_notification(void);
+
     std::map<std::string, sai_object_id_t> bfd_session_map;
     std::map<sai_object_id_t, BfdUpdate> bfd_session_lookup;
 
     swss::Table m_stateBfdSessionTable;
 
     swss::NotificationConsumer* m_bfdStateNotificationConsumer;
+    bool register_state_change_notif;
 };
 
 #endif /* SWSS_BFDORCH_H */

--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -475,6 +475,7 @@ void FdbOrch::update(sai_fdb_event_t        type,
         }
 
         update.add = true;
+	update.entry.port_name = update.port.m_alias;
         if (!port_old.m_alias.empty())
         {
             port_old.m_fdb_count--;

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -478,10 +478,6 @@ int main(int argc, char **argv)
     attr.value.ptr = (void *)on_port_state_change;
     attrs.push_back(attr);
 
-    attr.id = SAI_SWITCH_ATTR_BFD_SESSION_STATE_CHANGE_NOTIFY;
-    attr.value.ptr = (void *)on_bfd_session_state_change;
-    attrs.push_back(attr);
-
     attr.id = SAI_SWITCH_ATTR_SHUTDOWN_REQUEST_NOTIFY;
     attr.value.ptr = (void *)on_switch_shutdown_request;
     attrs.push_back(attr);

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -34,6 +34,7 @@ const char state_db_key_delimiter  = '|';
 #define INVM_PLATFORM_SUBSTRING "innovium"
 #define MLNX_PLATFORM_SUBSTRING "mellanox"
 #define BRCM_PLATFORM_SUBSTRING "broadcom"
+#define BRCM_DNX_PLATFORM_SUBSTRING "broadcom-dnx"
 #define BFN_PLATFORM_SUBSTRING  "barefoot"
 #define VS_PLATFORM_SUBSTRING   "vs"
 #define NPS_PLATFORM_SUBSTRING  "nephos"

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -98,13 +98,11 @@ map<string, string> qos_to_ref_table_map = {
 #define DSCP_MAX_VAL 63
 #define EXP_MAX_VAL 7
 
-task_process_status QosMapHandler::processWorkItem(Consumer& consumer)
+task_process_status QosMapHandler::processWorkItem(Consumer& consumer, KeyOpFieldsValuesTuple &tuple)
 {
     SWSS_LOG_ENTER();
 
     sai_object_id_t sai_object = SAI_NULL_OBJECT_ID;
-    auto it = consumer.m_toSync.begin();
-    KeyOpFieldsValuesTuple tuple = it->second;
     string qos_object_name = kfvKey(tuple);
     string qos_map_type_name = consumer.getTableName();
     string op = kfvOp(tuple);
@@ -321,11 +319,11 @@ bool DscpToTcMapHandler::removeQosItem(sai_object_id_t sai_object)
     return true;
 }
 
-task_process_status QosOrch::handleDscpToTcTable(Consumer& consumer)
+task_process_status QosOrch::handleDscpToTcTable(Consumer& consumer, KeyOpFieldsValuesTuple &tuple)
 {
     SWSS_LOG_ENTER();
     DscpToTcMapHandler dscp_tc_handler;
-    return dscp_tc_handler.processWorkItem(consumer);
+    return dscp_tc_handler.processWorkItem(consumer, tuple);
 }
 
 bool MplsTcToTcMapHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &tuple, vector<sai_attribute_t> &attributes)
@@ -376,11 +374,11 @@ sai_object_id_t MplsTcToTcMapHandler::addQosItem(const vector<sai_attribute_t> &
     return sai_object;
 }
 
-task_process_status QosOrch::handleMplsTcToTcTable(Consumer& consumer)
+task_process_status QosOrch::handleMplsTcToTcTable(Consumer& consumer, KeyOpFieldsValuesTuple &tuple)
 {
     SWSS_LOG_ENTER();
     MplsTcToTcMapHandler mpls_tc_to_tc_handler;
-    return mpls_tc_to_tc_handler.processWorkItem(consumer);
+    return mpls_tc_to_tc_handler.processWorkItem(consumer, tuple);
 }
 
 bool Dot1pToTcMapHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &tuple, vector<sai_attribute_t> &attributes)
@@ -445,11 +443,11 @@ sai_object_id_t Dot1pToTcMapHandler::addQosItem(const vector<sai_attribute_t> &a
     return object_id;
 }
 
-task_process_status QosOrch::handleDot1pToTcTable(Consumer &consumer)
+task_process_status QosOrch::handleDot1pToTcTable(Consumer &consumer, KeyOpFieldsValuesTuple &tuple)
 {
     SWSS_LOG_ENTER();
     Dot1pToTcMapHandler dot1p_tc_handler;
-    return dot1p_tc_handler.processWorkItem(consumer);
+    return dot1p_tc_handler.processWorkItem(consumer, tuple);
 }
 
 bool TcToQueueMapHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &tuple, vector<sai_attribute_t> &attributes)
@@ -498,11 +496,11 @@ sai_object_id_t TcToQueueMapHandler::addQosItem(const vector<sai_attribute_t> &a
     return sai_object;
 }
 
-task_process_status QosOrch::handleTcToQueueTable(Consumer& consumer)
+task_process_status QosOrch::handleTcToQueueTable(Consumer& consumer, KeyOpFieldsValuesTuple &tuple)
 {
     SWSS_LOG_ENTER();
     TcToQueueMapHandler tc_queue_handler;
-    return tc_queue_handler.processWorkItem(consumer);
+    return tc_queue_handler.processWorkItem(consumer, tuple);
 }
 
 void WredMapHandler::freeAttribResources(vector<sai_attribute_t> &attributes)
@@ -719,11 +717,11 @@ bool WredMapHandler::removeQosItem(sai_object_id_t sai_object)
     return true;
 }
 
-task_process_status QosOrch::handleWredProfileTable(Consumer& consumer)
+task_process_status QosOrch::handleWredProfileTable(Consumer& consumer, KeyOpFieldsValuesTuple &tuple)
 {
     SWSS_LOG_ENTER();
     WredMapHandler wred_handler;
-    return wred_handler.processWorkItem(consumer);
+    return wred_handler.processWorkItem(consumer, tuple);
 }
 
 bool TcToPgHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &tuple, vector<sai_attribute_t> &attributes)
@@ -772,11 +770,11 @@ sai_object_id_t TcToPgHandler::addQosItem(const vector<sai_attribute_t> &attribu
 
 }
 
-task_process_status QosOrch::handleTcToPgTable(Consumer& consumer)
+task_process_status QosOrch::handleTcToPgTable(Consumer& consumer, KeyOpFieldsValuesTuple &tuple)
 {
     SWSS_LOG_ENTER();
     TcToPgHandler tc_to_pg_handler;
-    return tc_to_pg_handler.processWorkItem(consumer);
+    return tc_to_pg_handler.processWorkItem(consumer, tuple);
 }
 
 bool PfcPrioToPgHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &tuple, vector<sai_attribute_t> &attributes)
@@ -826,11 +824,11 @@ sai_object_id_t PfcPrioToPgHandler::addQosItem(const vector<sai_attribute_t> &at
 
 }
 
-task_process_status QosOrch::handlePfcPrioToPgTable(Consumer& consumer)
+task_process_status QosOrch::handlePfcPrioToPgTable(Consumer& consumer, KeyOpFieldsValuesTuple &tuple)
 {
     SWSS_LOG_ENTER();
     PfcPrioToPgHandler pfc_prio_to_pg_handler;
-    return pfc_prio_to_pg_handler.processWorkItem(consumer);
+    return pfc_prio_to_pg_handler.processWorkItem(consumer, tuple);
 }
 
 bool PfcToQueueHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &tuple, vector<sai_attribute_t> &attributes)
@@ -967,11 +965,11 @@ sai_object_id_t DscpToFcMapHandler::addQosItem(const vector<sai_attribute_t> &at
     return sai_object;
 }
 
-task_process_status QosOrch::handleDscpToFcTable(Consumer& consumer)
+task_process_status QosOrch::handleDscpToFcTable(Consumer& consumer, KeyOpFieldsValuesTuple &tuple)
 {
     SWSS_LOG_ENTER();
     DscpToFcMapHandler dscp_fc_handler;
-    return dscp_fc_handler.processWorkItem(consumer);
+    return dscp_fc_handler.processWorkItem(consumer, tuple);
 }
 
 bool ExpToFcMapHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &tuple,
@@ -1058,18 +1056,18 @@ sai_object_id_t ExpToFcMapHandler::addQosItem(const vector<sai_attribute_t> &att
     return sai_object;
 }
 
-task_process_status QosOrch::handleExpToFcTable(Consumer& consumer)
+task_process_status QosOrch::handleExpToFcTable(Consumer& consumer, KeyOpFieldsValuesTuple &tuple)
 {
     SWSS_LOG_ENTER();
     ExpToFcMapHandler exp_fc_handler;
-    return exp_fc_handler.processWorkItem(consumer);
+    return exp_fc_handler.processWorkItem(consumer, tuple);
 }
 
-task_process_status QosOrch::handlePfcToQueueTable(Consumer& consumer)
+task_process_status QosOrch::handlePfcToQueueTable(Consumer& consumer, KeyOpFieldsValuesTuple &tuple)
 {
     SWSS_LOG_ENTER();
     PfcToQueueHandler pfc_to_queue_handler;
-    return pfc_to_queue_handler.processWorkItem(consumer);
+    return pfc_to_queue_handler.processWorkItem(consumer, tuple);
 }
 
 QosOrch::QosOrch(DBConnector *db, vector<string> &tableNames) : Orch(db, tableNames)
@@ -1104,14 +1102,13 @@ void QosOrch::initTableHandlers()
     m_qos_handler_map.insert(qos_handler_pair(CFG_PFC_PRIORITY_TO_QUEUE_MAP_TABLE_NAME, &QosOrch::handlePfcToQueueTable));
 }
 
-task_process_status QosOrch::handleSchedulerTable(Consumer& consumer)
+task_process_status QosOrch::handleSchedulerTable(Consumer& consumer, KeyOpFieldsValuesTuple &tuple)
 {
     SWSS_LOG_ENTER();
 
     sai_status_t sai_status;
     sai_object_id_t sai_object = SAI_NULL_OBJECT_ID;
 
-    KeyOpFieldsValuesTuple tuple = consumer.m_toSync.begin()->second;
     string qos_map_type_name = CFG_SCHEDULER_TABLE_NAME;
     string qos_object_name = kfvKey(tuple);
     string op = kfvOp(tuple);
@@ -1457,11 +1454,9 @@ bool QosOrch::applyWredProfileToQueue(Port &port, size_t queue_ind, sai_object_i
     return true;
 }
 
-task_process_status QosOrch::handleQueueTable(Consumer& consumer)
+task_process_status QosOrch::handleQueueTable(Consumer& consumer, KeyOpFieldsValuesTuple &tuple)
 {
     SWSS_LOG_ENTER();
-    auto it = consumer.m_toSync.begin();
-    KeyOpFieldsValuesTuple tuple = it->second;
     Port port;
     bool result;
     string key = kfvKey(tuple);
@@ -1690,11 +1685,10 @@ task_process_status QosOrch::ResolveMapAndApplyToPort(
     return task_process_status::task_success;
 }
 
-task_process_status QosOrch::handlePortQosMapTable(Consumer& consumer)
+task_process_status QosOrch::handlePortQosMapTable(Consumer& consumer, KeyOpFieldsValuesTuple &tuple)
 {
     SWSS_LOG_ENTER();
 
-    KeyOpFieldsValuesTuple tuple = consumer.m_toSync.begin()->second;
     string key = kfvKey(tuple);
     string op = kfvOp(tuple);
     vector<string> port_names = tokenize(key, list_item_delimiter);
@@ -1898,7 +1892,7 @@ void QosOrch::doTask(Consumer &consumer)
             continue;
         }
 
-        auto task_status = (this->*(m_qos_handler_map[qos_map_type_name]))(consumer);
+        auto task_status = (this->*(m_qos_handler_map[qos_map_type_name]))(consumer, it->second);
         switch(task_status)
         {
             case task_process_status::task_success :

--- a/orchagent/qosorch.h
+++ b/orchagent/qosorch.h
@@ -59,7 +59,7 @@ const string ecn_all                            = "ecn_all";
 class QosMapHandler
 {
 public:
-    task_process_status processWorkItem(Consumer& consumer);
+    task_process_status processWorkItem(Consumer& consumer, KeyOpFieldsValuesTuple &tuple);
     virtual bool convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &tuple, vector<sai_attribute_t> &attributes) = 0;
     virtual void freeAttribResources(vector<sai_attribute_t> &attributes);
     virtual bool modifyQosItem(sai_object_id_t, vector<sai_attribute_t> &attributes);
@@ -158,25 +158,25 @@ private:
     void doTask() override;
     virtual void doTask(Consumer& consumer);
 
-    typedef task_process_status (QosOrch::*qos_table_handler)(Consumer& consumer);
+    typedef task_process_status (QosOrch::*qos_table_handler)(Consumer& consumer, KeyOpFieldsValuesTuple &tuple);
     typedef map<string, qos_table_handler> qos_table_handler_map;
     typedef pair<string, qos_table_handler> qos_handler_pair;
 
     void initTableHandlers();
 
-    task_process_status handleDscpToTcTable(Consumer& consumer);
-    task_process_status handleMplsTcToTcTable(Consumer& consumer);
-    task_process_status handleDot1pToTcTable(Consumer& consumer);
-    task_process_status handlePfcPrioToPgTable(Consumer& consumer);
-    task_process_status handlePfcToQueueTable(Consumer& consumer);
-    task_process_status handlePortQosMapTable(Consumer& consumer);
-    task_process_status handleTcToPgTable(Consumer& consumer);
-    task_process_status handleTcToQueueTable(Consumer& consumer);
-    task_process_status handleSchedulerTable(Consumer& consumer);
-    task_process_status handleQueueTable(Consumer& consumer);
-    task_process_status handleWredProfileTable(Consumer& consumer);
-    task_process_status handleDscpToFcTable(Consumer& consumer);
-    task_process_status handleExpToFcTable(Consumer& consumer);
+    task_process_status handleDscpToTcTable(Consumer& consumer, KeyOpFieldsValuesTuple &tuple);
+    task_process_status handleMplsTcToTcTable(Consumer& consumer, KeyOpFieldsValuesTuple &tuple);
+    task_process_status handleDot1pToTcTable(Consumer& consumer, KeyOpFieldsValuesTuple &tuple);
+    task_process_status handlePfcPrioToPgTable(Consumer& consumer, KeyOpFieldsValuesTuple &tuple);
+    task_process_status handlePfcToQueueTable(Consumer& consumer, KeyOpFieldsValuesTuple &tuple);
+    task_process_status handlePortQosMapTable(Consumer& consumer, KeyOpFieldsValuesTuple &tuple);
+    task_process_status handleTcToPgTable(Consumer& consumer, KeyOpFieldsValuesTuple &tuple);
+    task_process_status handleTcToQueueTable(Consumer& consumer, KeyOpFieldsValuesTuple &tuple);
+    task_process_status handleSchedulerTable(Consumer& consumer, KeyOpFieldsValuesTuple &tuple);
+    task_process_status handleQueueTable(Consumer& consumer, KeyOpFieldsValuesTuple &tuple);
+    task_process_status handleWredProfileTable(Consumer& consumer, KeyOpFieldsValuesTuple &tuple);
+    task_process_status handleDscpToFcTable(Consumer& consumer, KeyOpFieldsValuesTuple &tuple);
+    task_process_status handleExpToFcTable(Consumer& consumer, KeyOpFieldsValuesTuple &tuple);
 
     sai_object_id_t getSchedulerGroup(const Port &port, const sai_object_id_t queue_id);
 

--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -1542,28 +1542,12 @@ bool VxlanTunnelOrch::removeVxlanTunnelMap(string tunnelName, uint32_t vni)
     tunnel_obj->vlan_vrf_vni_count--;
     if (tunnel_obj->vlan_vrf_vni_count == 0)
     {
-        auto tunnel_term_id = vxlan_tunnel_table_[tunnelName].get()->getTunnelTermId();
-        try
-        {
-            remove_tunnel_termination(tunnel_term_id);
-        }
-        catch(const std::runtime_error& error)
-        {
-            SWSS_LOG_ERROR("Error removing tunnel term entry. Tunnel: %s. Error: %s", tunnelName.c_str(), error.what());
-            return false;
-        }
- 
-        auto tunnel_id = vxlan_tunnel_table_[tunnelName].get()->getTunnelId();
-        try
-        {
-            removeTunnelFromFlexCounter(tunnel_id, tunnelName);
-            remove_tunnel(tunnel_id);
-        }
-        catch(const std::runtime_error& error)
-        {
-            SWSS_LOG_ERROR("Error removing tunnel entry. Tunnel: %s. Error: %s", tunnelName.c_str(), error.what());
-            return false;
-        }
+       uint8_t mapper_list = 0;
+
+       TUNNELMAP_SET_VLAN(mapper_list);
+       TUNNELMAP_SET_VRF(mapper_list);
+
+       tunnel_obj->deleteTunnelHw(mapper_list, TUNNEL_MAP_USE_DEDICATED_ENCAP_DECAP);
     }
 
     SWSS_LOG_NOTICE("Vxlan map entry deleted for tunnel '%s' with vni '%d'", tunnelName.c_str(), vni);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Bugfix: The notifications cannot be drained in QosOrch in case the first one needs to retry

**Why I did it**
Bugfix

**How I verified it**

Mock test and manual test.

**Details if related**
This is because both `doTask` and the table handlers take `consumer` as the argument.
In `doTask`, each notification is iterated in the main loop and passed to table handlers. However, `consumer` is passed to table handlers, which makes it unable to access the rest notifications following the first one. In case the first one needs to retry and remains in `m_toSync`, the rest notifications do not have opportunity to run.