### PR TITLE
[QoS][Bugfix] Resolve an issue in the sequence where a referenced object removed and then the referencing object deleting and then re-adding

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -389,6 +389,11 @@ task_process_status BufferOrch::processBufferPool(KeyOpFieldsValuesTuple &tuple)
     {
         sai_object = (*(m_buffer_type_maps[map_type_name]))[object_name].m_saiObjectId;
         SWSS_LOG_DEBUG("found existing object:%s of type:%s", object_name.c_str(), map_type_name.c_str());
+        if ((*(m_buffer_type_maps[map_type_name]))[object_name].m_pendingRemove && op == SET_COMMAND)
+        {
+            SWSS_LOG_NOTICE("Entry %s %s is pending remove, need retry", map_type_name.c_str(), object_name.c_str());
+            return task_process_status::task_need_retry;
+        }
     }
     SWSS_LOG_DEBUG("processing command:%s", op.c_str());
     if (object_name == "ingress_zero_pool")
@@ -565,6 +570,7 @@ task_process_status BufferOrch::processBufferPool(KeyOpFieldsValuesTuple &tuple)
             }
 
             (*(m_buffer_type_maps[map_type_name]))[object_name].m_saiObjectId = sai_object;
+            (*(m_buffer_type_maps[map_type_name]))[object_name].m_pendingRemove = false;
             // Here we take the PFC watchdog approach to update the COUNTERS_DB metadata (e.g., PFC_WD_DETECTION_TIME per queue)
             // at initialization (creation and registration phase)
             // Specifically, we push the buffer pool name to oid mapping upon the creation of the oid
@@ -579,6 +585,7 @@ task_process_status BufferOrch::processBufferPool(KeyOpFieldsValuesTuple &tuple)
         {
             auto hint = objectReferenceInfo(m_buffer_type_maps, map_type_name, object_name);
             SWSS_LOG_NOTICE("Can't remove object %s due to being referenced (%s)", object_name.c_str(), hint.c_str());
+            (*(m_buffer_type_maps[map_type_name]))[object_name].m_pendingRemove = true;
 
             return task_process_status::task_need_retry;
         }
@@ -647,6 +654,11 @@ task_process_status BufferOrch::processBufferProfile(KeyOpFieldsValuesTuple &tup
     {
         sai_object = (*(m_buffer_type_maps[map_type_name]))[object_name].m_saiObjectId;
         SWSS_LOG_DEBUG("found existing object:%s of type:%s", object_name.c_str(), map_type_name.c_str());
+        if ((*(m_buffer_type_maps[map_type_name]))[object_name].m_pendingRemove && op == SET_COMMAND)
+        {
+            SWSS_LOG_NOTICE("Entry %s %s is pending remove, need retry", map_type_name.c_str(), object_name.c_str());
+            return task_process_status::task_need_retry;
+        }
     }
     SWSS_LOG_DEBUG("processing command:%s", op.c_str());
     if (op == SET_COMMAND)
@@ -794,6 +806,7 @@ task_process_status BufferOrch::processBufferProfile(KeyOpFieldsValuesTuple &tup
                 }
             }
             (*(m_buffer_type_maps[map_type_name]))[object_name].m_saiObjectId = sai_object;
+            (*(m_buffer_type_maps[map_type_name]))[object_name].m_pendingRemove = false;
             SWSS_LOG_NOTICE("Created buffer profile %s with type %s", object_name.c_str(), map_type_name.c_str());
         }
 
@@ -806,6 +819,7 @@ task_process_status BufferOrch::processBufferProfile(KeyOpFieldsValuesTuple &tup
         {
             auto hint = objectReferenceInfo(m_buffer_type_maps, map_type_name, object_name);
             SWSS_LOG_NOTICE("Can't remove object %s due to being referenced (%s)", object_name.c_str(), hint.c_str());
+            (*(m_buffer_type_maps[map_type_name]))[object_name].m_pendingRemove = true;
 
             return task_process_status::task_need_retry;
         }

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -357,6 +357,11 @@ bool Orch::parseReference(type_map &type_maps, string &ref_in, const string &typ
         SWSS_LOG_INFO("map:%s does not contain object with name:%s\n", type_name.c_str(), ref_in.c_str());
         return false;
     }
+    if (obj_it->second.m_pendingRemove)
+    {
+        SWSS_LOG_NOTICE("map:%s contains a pending removed object %s, skip\n", type_name.c_str(), ref_in.c_str());
+        return false;
+    }
     object_name = ref_in;
     SWSS_LOG_DEBUG("parsed: type_name:%s, object_name:%s", type_name.c_str(), object_name.c_str());
     return true;

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -66,6 +66,7 @@ typedef struct
     // multiple objects being referenced are separated by ','
     std::map<std::string, std::string> m_objsReferencingByMe;
     sai_object_id_t m_saiObjectId;
+    bool m_pendingRemove;
 } referenced_object;
 
 typedef std::map<std::string, referenced_object> object_reference_map;

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -1662,6 +1662,18 @@ task_process_status QosOrch::ResolveMapAndApplyToPort(
 {
     SWSS_LOG_ENTER();
 
+    if (op == DEL_COMMAND)
+    {
+        // NOTE: The map is un-bound from the port. But the map itself still exists.
+        applyMapToPort(port, port_attr, SAI_NULL_OBJECT_ID);
+        return task_process_status::task_success;
+    }
+    else if (op != SET_COMMAND)
+    {
+        SWSS_LOG_ERROR("Unknown operation type %s", op.c_str());
+        return task_process_status::task_invalid_entry;
+    }
+
     sai_object_id_t sai_object = SAI_NULL_OBJECT_ID;
     string object_name;
     bool result;
@@ -1669,20 +1681,7 @@ task_process_status QosOrch::ResolveMapAndApplyToPort(
                            qos_to_ref_table_map.at(field_name), tuple, sai_object, object_name);
     if (ref_resolve_status::success == resolve_result)
     {
-        if (op == SET_COMMAND)
-        {
-            result = applyMapToPort(port, port_attr, sai_object);
-        }
-        else if (op == DEL_COMMAND)
-        {
-            // NOTE: The map is un-bound from the port. But the map itself still exists.
-            result = applyMapToPort(port, port_attr, SAI_NULL_OBJECT_ID);
-        }
-        else
-        {
-            SWSS_LOG_ERROR("Unknown operation type %s", op.c_str());
-            return task_process_status::task_invalid_entry;
-        }
+        result = applyMapToPort(port, port_attr, sai_object);
         if (!result)
         {
             SWSS_LOG_ERROR("Failed setting field:%s to port:%s, line:%d", field_name.c_str(), port.m_alias.c_str(), __LINE__);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Resolve an issue in the following scenario
Suppose object `a` in table `A` references object `b` in table `B`. When a user is going to remove items in table `A` and `B`, the notifications can be received in the following order:
1. The notification of removing object `b`
2. Then the notification of removing object `a`
3. And then the notification of re-adding object `a`
4. The notification of re-adding object `b`.

Object `b` can not be removed in the 1st step because it is still referenced by object `a`. In case the system is busy, the notification of removing `a` remains in `m_toSync` when the notification of re-adding it is coming, which results in both notifications being handled together and the reference to object `b` not being cleared.
As a result, notification of removing `b` will never be handled and remain in `m_toSync` forever.

Solution:
- Introduce a flag `pending remove` indicating whether an object is about to be removed but pending on some reference.
  - `pending remove` is set once a `DEL` notification is received for an object with non-zero reference.
- When resolving references in step 3, a `pending remove` object will be skipped and the notification will remain in `m_toSync`.
- `SET` operation will not be carried out in case there is a `pending remove` flag on the object to be set.

By doing so, when object `a` is re-added in step 3, it can not retrieve the dependent object `b`. And step 1 will be handled and drained successfully.

**Why I did it**
Fix bug.

**How I verified it**
Mock test and manually test (eg. `config qos reload`)

**Details if related**
