### PR TITLE
Fix issues in dynamic buffer in rare scenario after "config qos clear"

### DIFF
--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -875,10 +875,8 @@ void BufferMgrDynamic::updateBufferProfileToDb(const string &name, const buffer_
     }
 
     vector<FieldValueTuple> fvVector;
-    string mode = getPgPoolMode();
 
-    // profile threshold field name
-    mode += "_th";
+    const string &&mode = profile.threshold_mode.empty() ? getPgPoolMode() + "_th" : profile.threshold_mode;
 
     if (profile.lossless)
     {
@@ -1430,9 +1428,9 @@ task_process_status BufferMgrDynamic::refreshPgsForPort(const string &port, cons
         return task_process_status::task_success;
     }
 
-    if (!m_bufferPoolReady)
+    if (!m_bufferPoolReady || m_defaultThreshold.empty())
     {
-        SWSS_LOG_INFO("Nothing to be done since the buffer pool is not ready");
+        SWSS_LOG_INFO("Nothing to be done since either the buffer pool or default threshold is not ready");
         return task_process_status::task_success;
     }
 
@@ -1454,6 +1452,12 @@ task_process_status BufferMgrDynamic::refreshPgsForPort(const string &port, cons
 
         if (portPg.dynamic_calculated)
         {
+            if (speed.empty())
+            {
+                SWSS_LOG_INFO("Nothing to be done for %s since no speed configured", key.c_str());
+                continue;
+            }
+
             string threshold;
             // Calculate new headroom size
             if (portPg.static_configured)
@@ -1909,6 +1913,10 @@ task_process_status BufferMgrDynamic::handleDefaultLossLessBufferParam(KeyOpFiel
                 SWSS_LOG_DEBUG("Handling Buffer parameter table field over_subscribe_ratio value %s", fvValue(i).c_str());
             }
         }
+    }
+    else if (op == DEL_COMMAND)
+    {
+        newRatio = "";
     }
     else
     {
@@ -2432,6 +2440,20 @@ task_process_status BufferMgrDynamic::handleBufferProfileTable(KeyOpFieldsValues
                     }
                     profileApp.pool_name = poolName;
                     profileApp.direction = poolRef->second.direction;
+                    auto threshold_mode = poolRef->second.mode + "_th";
+                    if (profileApp.threshold_mode.empty())
+                    {
+                        profileApp.threshold_mode = threshold_mode;
+                    }
+                    else if (profileApp.threshold_mode != threshold_mode)
+                    {
+                        SWSS_LOG_ERROR("Buffer profile %s's mode %s doesn't match with buffer pool %s whose mode is %s",
+                                       profileName.c_str(),
+                                       profileApp.threshold_mode.c_str(),
+                                       poolName.c_str(),
+                                       threshold_mode.c_str());
+                        return task_process_status::task_failed;
+                    }
                 }
                 else
                 {
@@ -2456,12 +2478,21 @@ task_process_status BufferMgrDynamic::handleBufferProfileTable(KeyOpFieldsValues
             {
                 profileApp.size = value;
             }
-            else if (field == buffer_dynamic_th_field_name)
+            else if (field == buffer_dynamic_th_field_name || field == buffer_static_th_field_name)
             {
-                profileApp.threshold = value;
-            }
-            else if (field == buffer_static_th_field_name)
-            {
+                if (profileApp.threshold_mode.empty())
+                {
+                    profileApp.threshold_mode = field;
+                }
+                else if (profileApp.threshold_mode != field)
+                {
+                    SWSS_LOG_ERROR("Buffer profile %s's mode %s doesn't align with buffer pool %s whose mode is %s",
+                                   profileName.c_str(),
+                                   field.c_str(),
+                                   profileApp.pool_name.c_str(),
+                                   profileApp.threshold_mode.c_str());
+                    return task_process_status::task_failed;
+                }
                 profileApp.threshold = value;
             }
             else if (field == buffer_headroom_type_field_name)
@@ -3189,6 +3220,7 @@ void BufferMgrDynamic::doTask(Consumer &consumer)
         {
             case task_process_status::task_failed:
                 SWSS_LOG_ERROR("Failed to process table update");
+                it = consumer.m_toSync.erase(it);
                 return;
             case task_process_status::task_need_retry:
                 SWSS_LOG_INFO("Unable to process table update. Will retry...");
@@ -3238,7 +3270,7 @@ void BufferMgrDynamic::doTask(Consumer &consumer)
  */
 void BufferMgrDynamic::handlePendingBufferObjects()
 {
-    if (m_bufferPoolReady)
+    if (m_bufferPoolReady && !m_defaultThreshold.empty())
     {
         if (!m_pendingApplyZeroProfilePorts.empty())
         {

--- a/cfgmgr/buffermgrdyn.h
+++ b/cfgmgr/buffermgrdyn.h
@@ -71,6 +71,7 @@ typedef struct {
     std::string xon_offset;
     std::string xoff;
     std::string threshold;
+    std::string threshold_mode;
     std::string pool_name;
     // port_pgs - stores pgs referencing this profile
     // An element will be added or removed when a PG added or removed

--- a/tests/buffer_model.py
+++ b/tests/buffer_model.py
@@ -1,8 +1,16 @@
 import re
 import time
 
+def initialize_lossless_parameters(config_db, cmd_runner):
+    default_lossless_param = {'default_dynamic_th': '0'}
+    config_db.update_entry('DEFAULT_LOSSLESS_BUFFER_PARAMETER', 'AZURE', default_lossless_param)
+
+    lossless_traffic_pattern = {'mtu': '1024', 'small_packet_percentage': '100'}
+    config_db.update_entry('LOSSLESS_TRAFFIC_PATTERN', 'AZURE', lossless_traffic_pattern)
+
+
 lossless_profile_name_pattern = 'pg_lossless_([1-9][0-9]*000)_([1-9][0-9]*m)_profile'
-def enable_dynamic_buffer(config_db, cmd_runner):
+def enable_dynamic_buffer(config_db, cmd_runner, full_init=True):
     # check whether it's already running dynamic mode
     device_meta = config_db.get_entry('DEVICE_METADATA', 'localhost')
     assert 'buffer_model' in device_meta, "'buffer_model' doesn't exist in DEVICE_METADATA|localhost"
@@ -43,11 +51,8 @@ def enable_dynamic_buffer(config_db, cmd_runner):
             if re.search(lossless_profile_name_pattern, key):
                 assert False, "dynamically generated profile still exists"
 
-        default_lossless_param = {'default_dynamic_th': '0'}
-        config_db.update_entry('DEFAULT_LOSSLESS_BUFFER_PARAMETER', 'AZURE', default_lossless_param)
-
-        lossless_traffic_pattern = {'mtu': '1024', 'small_packet_percentage': '100'}
-        config_db.update_entry('LOSSLESS_TRAFFIC_PATTERN', 'AZURE', lossless_traffic_pattern)
+        if full_init:
+            initialize_lossless_parameters(config_db, cmd_runner)
     finally:
         # restart daemon
         cmd_runner("supervisorctl restart buffermgrd")


### PR DESCRIPTION
1. Do not generate dynamic lossless buffer profiles in case default_dynamic_th is not ready.
2. For non-dynamic lossless buffer profiles
  - record threshold mode from CONFIG_DB
  - do not apply if the threshold mode doesn't aligh with buffer pool
3. Remove an item from m_toSync on failure

Signed-off-by: Stephen Sun <stephens@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
