### PR TITLE
Support mock test for dynamic buffer manager

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -39,7 +39,7 @@ jobs:
       pipeline: 9
       artifact: ${{ parameters.swss_common_artifact_name }}
       runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/master'
+      runBranch: 'refs/heads/$(BUILD_BRANCH)'
     displayName: "Download sonic swss common deb packages"
   - task: DownloadPipelineArtifact@2
     inputs:
@@ -48,7 +48,7 @@ jobs:
       pipeline: 12
       artifact: ${{ parameters.sairedis_artifact_name }}
       runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/master'
+      runBranch: 'refs/heads/$(BUILD_BRANCH)'
     displayName: "Download sonic sairedis deb packages"
   - task: DownloadPipelineArtifact@2
     inputs:
@@ -61,13 +61,12 @@ jobs:
       pipeline: 1
       artifact: sonic-buildimage.vs
       runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/master'
+      runBranch: 'refs/heads/$(BUILD_BRANCH)'
     displayName: "Download sonic buildimage"
   - script: |
       echo $(Build.DefinitionName).$(Build.BuildNumber)
 
       docker load < ../target/docker-sonic-vs.gz
-
       mkdir -p .azure-pipelines/docker-sonic-vs/debs
 
       cp -v ../*.deb .azure-pipelines/docker-sonic-vs/debs

--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -36,40 +36,47 @@ jobs:
     inputs:
       source: specific
       project: build
-      pipeline: 9
+      pipeline: Azure.sonic-swss-common
       artifact: ${{ parameters.swss_common_artifact_name }}
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/$(BUILD_BRANCH)'
+      path: $(Build.ArtifactStagingDirectory)/download
     displayName: "Download sonic swss common deb packages"
   - task: DownloadPipelineArtifact@2
     inputs:
       source: specific
       project: build
-      pipeline: 12
+      pipeline: Azure.sonic-sairedis
       artifact: ${{ parameters.sairedis_artifact_name }}
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/$(BUILD_BRANCH)'
+      path: $(Build.ArtifactStagingDirectory)/download
     displayName: "Download sonic sairedis deb packages"
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: ${{ parameters.swss_artifact_name }}
-    displayName: "Download sonic swss artifact"
+      path: $(Build.ArtifactStagingDirectory)/download
+    displayName: "Download pre-stage built ${{ parameters.swss_artifact_name }}"
   - task: DownloadPipelineArtifact@2
     inputs:
       source: specific
       project: build
-      pipeline: 1
+      pipeline: Azure.sonic-buildimage.official.vs
       artifact: sonic-buildimage.vs
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/$(BUILD_BRANCH)'
-    displayName: "Download sonic buildimage"
+      path: $(Build.ArtifactStagingDirectory)/download
+      patterns: '**/target/docker-sonic-vs.gz'
+    displayName: "Download sonic-buildimage docker-sonic-vs"
   - script: |
+      set -ex
       echo $(Build.DefinitionName).$(Build.BuildNumber)
 
-      docker load < ../target/docker-sonic-vs.gz
+      docker load < $(Build.ArtifactStagingDirectory)/download/target/docker-sonic-vs.gz
+
       mkdir -p .azure-pipelines/docker-sonic-vs/debs
 
-      cp -v ../*.deb .azure-pipelines/docker-sonic-vs/debs
+      cp -v $(Build.ArtifactStagingDirectory)/download/*.deb .azure-pipelines/docker-sonic-vs/debs
 
       pushd .azure-pipelines
 
@@ -78,7 +85,8 @@ jobs:
       popd
 
       docker save docker-sonic-vs:$(Build.DefinitionName).$(Build.BuildNumber) | gzip -c > $(Build.ArtifactStagingDirectory)/docker-sonic-vs.gz
-
+      rm -rf $(Build.ArtifactStagingDirectory)/download
+    displayName: "Build docker-sonic-vs"
   - publish: $(Build.ArtifactStagingDirectory)/
     artifact: ${{ parameters.artifact_name }}
     displayName: "Archive sonic docker vs image"

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -23,12 +23,6 @@ parameters:
 - name: sonic_slave
   type: string
 
-- name: buildimage_artifact_name
-  type: string
-
-- name: buildimage_pipeline
-  type: number
-
 - name: sairedis_artifact_name
   type: string
 
@@ -45,6 +39,9 @@ parameters:
 - name: archive_gcov
   type: boolean
   default: false
+
+- name: common_lib_artifact_name
+  type: string
 
 jobs:
 - job:
@@ -79,77 +76,63 @@ jobs:
     inputs:
       source: specific
       project: build
-      pipeline: 9
+      pipeline: Azure.sonic-swss-common
       artifact: ${{ parameters.swss_common_artifact_name }}
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/$(BUILD_BRANCH)'
-      path: '$(Build.SourcesDirectory)/${{ parameters.swss_common_artifact_name }}'
+      path: $(Build.ArtifactStagingDirectory)/download
+      patterns: |
+        libswsscommon_1.0.0_${{ parameters.arch }}.deb
+        libswsscommon-dev_1.0.0_${{ parameters.arch }}.deb
     displayName: "Download sonic swss common deb packages"
   - task: DownloadPipelineArtifact@2
     inputs:
       source: specific
       project: build
-      pipeline: 12
+      pipeline: Azure.sonic-sairedis
       artifact: ${{ parameters.sairedis_artifact_name }}
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/$(BUILD_BRANCH)'
-      path: '$(Build.SourcesDirectory)/${{ parameters.sairedis_artifact_name }}'
+      path: $(Build.ArtifactStagingDirectory)/download
+      patterns: |
+        libsaivs_*.deb
+        libsaivs-dev_*.deb
+        libsairedis_*.deb
+        libsairedis-dev_*.deb
+        libsaimetadata_*.deb
+        libsaimetadata-dev_*.deb
+        syncd-vs_*.deb
     displayName: "Download sonic sairedis deb packages"
   - task: DownloadPipelineArtifact@2
-    ${{ if eq(parameters.buildimage_pipeline, 141) }}:
-      continueOnError: True
     inputs:
       source: specific
       project: build
-      pipeline: ${{ parameters.buildimage_pipeline }}
-      artifact: ${{ parameters.buildimage_artifact_name }}
+      pipeline: Azure.sonic-buildimage.common_libs
+      artifact: ${{ parameters.common_lib_artifact_name }}
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/$(BUILD_BRANCH)'
-      path: '$(Build.SourcesDirectory)/${{ parameters.buildimage_artifact_name }}'
-    displayName: "Download sonic buildimage deb packages"
+      path: $(Build.ArtifactStagingDirectory)/download
+      patterns: |
+        target/debs/buster/libnl-3-200_*.deb
+        target/debs/buster/libnl-3-dev_*.deb
+        target/debs/buster/libnl-genl-3-200_*.deb
+        target/debs/buster/libnl-genl-3-dev_*.deb
+        target/debs/buster/libnl-route-3-200_*.deb
+        target/debs/buster/libnl-route-3-dev_*.deb
+        target/debs/buster/libnl-nf-3-200_*.deb
+        target/debs/buster/libnl-nf-3-dev_*.deb
+    displayName: "Download common libs"
   - script: |
-      buildimage_artifact_downloaded=n
-      [ -d "$(Build.SourcesDirectory)/${{ parameters.buildimage_artifact_name }}/target" ] && buildimage_artifact_downloaded=y
-      echo "buildimage_artifact_downloaded=$buildimage_artifact_downloaded"
-      echo "##vso[task.setvariable variable=buildimage_artifact_downloaded]$buildimage_artifact_downloaded"
-    condition: eq(${{ parameters.buildimage_pipeline }}, 141)
-    displayName: "Check if sonic buildimage deb packages downloaded"
-  - task: DownloadPipelineArtifact@2
-    condition: and(eq(variables.buildimage_artifact_downloaded, 'n'), eq(${{ parameters.buildimage_pipeline }}, 141))
-    inputs:
-      source: specific
-      project: build
-      pipeline: ${{ parameters.buildimage_pipeline }}
-      artifact: 'sonic-buildimage.marvell-armhf1'
-      runVersion: specific
-      runId: 80637
-      path: '$(Build.SourcesDirectory)/${{ parameters.buildimage_artifact_name }}'
-    displayName: "Download sonic buildimage deb packages from 80637"
-  - script: |
-      cd $(Build.SourcesDirectory)/${{ parameters.buildimage_artifact_name }}
-      sudo dpkg -i target/debs/buster/libnl-3-200_*.deb
-      sudo dpkg -i target/debs/buster/libnl-3-dev_*.deb
-      sudo dpkg -i target/debs/buster/libnl-genl-3-200_*.deb
-      sudo dpkg -i target/debs/buster/libnl-genl-3-dev_*.deb
-      sudo dpkg -i target/debs/buster/libnl-route-3-200_*.deb
-      sudo dpkg -i target/debs/buster/libnl-route-3-dev_*.deb
-      sudo dpkg -i target/debs/buster/libnl-nf-3-200_*.deb
-      sudo dpkg -i target/debs/buster/libnl-nf-3-dev_*.deb
-      cd $(Build.SourcesDirectory)/${{ parameters.swss_common_artifact_name }}
-      sudo dpkg -i libswsscommon_1.0.0_${{ parameters.arch }}.deb
-      sudo dpkg -i libswsscommon-dev_1.0.0_${{ parameters.arch }}.deb
-      cd $(Build.SourcesDirectory)/${{ parameters.sairedis_artifact_name }}
-      sudo dpkg -i libsaivs_*.deb
-      sudo dpkg -i libsaivs-dev_*.deb
-      sudo dpkg -i libsairedis_*.deb
-      sudo dpkg -i libsairedis-dev_*.deb
-      sudo dpkg -i libsaimetadata_*.deb
-      sudo dpkg -i libsaimetadata-dev_*.deb
-      sudo dpkg -i syncd-vs_*.deb
-    workingDirectory: $(Pipeline.Workspace)
+      set -ex
+      cd download
+      sudo dpkg -i $(find target/debs/buster -type f)
+      sudo dpkg -i $(ls *.deb)
+      cd ..
+      rm -rf download
+    workingDirectory: $(Build.ArtifactStagingDirectory)
     displayName: "Install libnl3, sonic swss common and sairedis"
   - script: |
-      set -x
+      set -ex
       tar czf pytest.tgz tests
       cp -r pytest.tgz $(Build.ArtifactStagingDirectory)/
       if [ '${{ parameters.archive_gcov }}' == True ]; then

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -54,7 +54,7 @@ jobs:
   pool:
     ${{ if ne(parameters.pool, 'default') }}:
       name: ${{ parameters.pool }}
-    ${{ if eq(parameters.pool, 'default') }}:
+    ${{ else }}:
       vmImage: 'ubuntu-20.04'
 
   container:
@@ -82,7 +82,7 @@ jobs:
       pipeline: 9
       artifact: ${{ parameters.swss_common_artifact_name }}
       runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/master'
+      runBranch: 'refs/heads/$(BUILD_BRANCH)'
       path: '$(Build.SourcesDirectory)/${{ parameters.swss_common_artifact_name }}'
     displayName: "Download sonic swss common deb packages"
   - task: DownloadPipelineArtifact@2
@@ -92,7 +92,7 @@ jobs:
       pipeline: 12
       artifact: ${{ parameters.sairedis_artifact_name }}
       runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/master'
+      runBranch: 'refs/heads/$(BUILD_BRANCH)'
       path: '$(Build.SourcesDirectory)/${{ parameters.sairedis_artifact_name }}'
     displayName: "Download sonic sairedis deb packages"
   - task: DownloadPipelineArtifact@2
@@ -104,7 +104,7 @@ jobs:
       pipeline: ${{ parameters.buildimage_pipeline }}
       artifact: ${{ parameters.buildimage_artifact_name }}
       runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/master'
+      runBranch: 'refs/heads/$(BUILD_BRANCH)'
       path: '$(Build.SourcesDirectory)/${{ parameters.buildimage_artifact_name }}'
     displayName: "Download sonic buildimage deb packages"
   - script: |

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -40,7 +40,7 @@ jobs:
       pipeline: 9
       artifact: sonic-swss-common.amd64.ubuntu20_04
       runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/master'
+      runBranch: 'refs/heads/$(BUILD_BRANCH)'
     displayName: "Download sonic swss common deb packages"
 
   - script: |

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -31,25 +31,26 @@ jobs:
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: docker-sonic-vs
-    displayName: "Download docker sonic vs image"
-
+      path: $(Build.ArtifactStagingDirectory)/download
+    displayName: "Download pre-stage built docker-sonic-vs"
   - task: DownloadPipelineArtifact@2
     inputs:
       source: specific
       project: build
-      pipeline: 9
+      pipeline: Azure.sonic-swss-common
       artifact: sonic-swss-common.amd64.ubuntu20_04
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/$(BUILD_BRANCH)'
+      path: $(Build.ArtifactStagingDirectory)/download
     displayName: "Download sonic swss common deb packages"
 
   - script: |
-      set -x
+      set -ex
       sudo .azure-pipelines/build_and_install_module.sh
 
       sudo apt-get install -y libhiredis0.14
-      sudo dpkg -i --force-confask,confnew ../libswsscommon_1.0.0_amd64.deb || apt-get install -f
-      sudo dpkg -i ../python3-swsscommon_1.0.0_amd64.deb
+      sudo dpkg -i --force-confask,confnew $(Build.ArtifactStagingDirectory)/download/libswsscommon_1.0.0_amd64.deb || apt-get install -f
+      sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/python3-swsscommon_1.0.0_amd64.deb
 
       # install packages for vs test
       sudo apt-get install -y net-tools bridge-utils vlan
@@ -58,8 +59,8 @@ jobs:
     displayName: "Install dependencies"
 
   - script: |
-      set -x
-      sudo docker load -i ../docker-sonic-vs.gz
+      set -ex
+      sudo docker load -i $(Build.ArtifactStagingDirectory)/download/docker-sonic-vs.gz
       docker ps
       ip netns list
       uname -a
@@ -72,6 +73,7 @@ jobs:
       else
         sudo py.test -v --force-flaky --junitxml=tr.xml --imgname=docker-sonic-vs:$(Build.DefinitionName).$(Build.BuildNumber)
       fi
+      rm -rf $(Build.ArtifactStagingDirectory)/download
     displayName: "Run vs tests"
 
   - task: PublishTestResults@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,10 +3,29 @@
 # Add steps that publish test results, save build artifacts, deploy, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/apps/c-cpp/gcc
 
+pr:
+- master
+- 202???
+- 201???
+
 trigger:
+  batch: true
   branches:
     include:
-      - "*"
+    - master
+    - 202???
+    - 201???
+
+# this part need to be set in UI
+schedules:
+- cron: "0 0 * * 6"
+  displayName: Weekly build
+  branches:
+    include:
+    - master
+    - 202???
+    - 201???
+  always: true
 
 stages:
 - stage: Build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,8 +42,7 @@ stages:
     parameters:
       arch: amd64
       sonic_slave: sonic-slave-buster
-      buildimage_artifact_name: sonic-buildimage.vs
-      buildimage_pipeline: 142
+      common_lib_artifact_name: common-lib
       swss_common_artifact_name: sonic-swss-common
       sairedis_artifact_name: sonic-sairedis
       artifact_name: sonic-swss
@@ -60,8 +59,7 @@ stages:
       timeout: 240
       pool: sonicbld-armhf
       sonic_slave: sonic-slave-buster-armhf
-      buildimage_artifact_name: sonic-buildimage.marvell-armhf
-      buildimage_pipeline: 141
+      common_lib_artifact_name: common-lib.armhf
       swss_common_artifact_name: sonic-swss-common.armhf
       sairedis_artifact_name: sonic-sairedis.armhf
       artifact_name: sonic-swss.armhf
@@ -73,9 +71,8 @@ stages:
       timeout: 240
       pool: sonicbld-arm64
       sonic_slave: sonic-slave-buster-arm64
+      common_lib_artifact_name: common-lib.arm64
       swss_common_artifact_name: sonic-swss-common.arm64
-      buildimage_artifact_name: sonic-buildimage.centec-arm64
-      buildimage_pipeline: 140
       sairedis_artifact_name: sonic-sairedis.arm64
       artifact_name: sonic-swss.arm64
       archive_gcov: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,6 +27,13 @@ schedules:
     - 201???
   always: true
 
+variables:
+  - name: BUILD_BRANCH
+    ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+      value: $(System.PullRequest.TargetBranch)
+    ${{ else }}:
+      value: $(Build.SourceBranchName)
+
 stages:
 - stage: Build
 

--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -1862,6 +1862,14 @@ task_process_status BufferMgrDynamic::handleBufferMaxParam(KeyOpFieldsValuesTupl
                     SWSS_LOG_INFO("BUFFER_MAX_PARAM: Got port %s's max priority group %s", key.c_str(), value.c_str());
 
                     portInfo.maximum_buffer_objects[BUFFER_PG] = (sai_uint32_t)pgCount;
+
+                    if (m_bufferCompletelyInitialized && portInfo.state == PORT_ADMIN_DOWN)
+                    {
+                        // This is mostly for the case where the port is created only-the-fly
+                        // The maximum buffer parameters can be received after buffer items
+                        reclaimReservedBufferForPort(key, m_portPgLookup, BUFFER_PG);
+                        SWSS_LOG_NOTICE("Admin-down port %s is handled after maximum buffer parameter has been received", key.c_str());
+                    }
                 }
                 else if (fvField(i) == "max_queues")
                 {
@@ -1875,6 +1883,14 @@ task_process_status BufferMgrDynamic::handleBufferMaxParam(KeyOpFieldsValuesTupl
                     SWSS_LOG_INFO("BUFFER_MAX_PARAM: Got port %s's max queue %s", key.c_str(), value.c_str());
 
                     portInfo.maximum_buffer_objects[BUFFER_QUEUE] = (sai_uint32_t)queueCount;
+
+                    if (m_bufferCompletelyInitialized && portInfo.state == PORT_ADMIN_DOWN)
+                    {
+                        // This is mostly for the case where the port is created only-the-fly
+                        // The maximum buffer parameters can be received after buffer items
+                        reclaimReservedBufferForPort(key, m_portQueueLookup, BUFFER_QUEUE);
+                        SWSS_LOG_NOTICE("Admin-down port %s is handled after maximum buffer parameter has been received", key.c_str());
+                    }
                 }
             }
         }
@@ -1961,6 +1977,7 @@ task_process_status BufferMgrDynamic::handleCableLenTable(KeyOpFieldsValuesTuple
     int failed_item_count = 0;
     if (op == SET_COMMAND)
     {
+        m_cableLengths.clear();
         for (auto i : kfvFieldsValues(tuple))
         {
             // receive and cache cable length table
@@ -1974,6 +1991,8 @@ task_process_status BufferMgrDynamic::handleCableLenTable(KeyOpFieldsValuesTuple
             SWSS_LOG_DEBUG("Port Info for %s before handling %s %s %s",
                            port.c_str(),
                            portInfo.effective_speed.c_str(), portInfo.cable_length.c_str(), portInfo.gearbox_model.c_str());
+
+            m_cableLengths[port] = cable_length;
 
             if (portInfo.cable_length == cable_length)
             {
@@ -2183,6 +2202,9 @@ task_process_status BufferMgrDynamic::handlePortTable(KeyOpFieldsValuesTuple &tu
         string &mtu = portInfo.mtu;
         string &effective_speed = portInfo.effective_speed;
 
+        if (cable_length.empty() && !m_cableLengths[port].empty())
+            cable_length = m_cableLengths[port];
+
         bool need_refresh_all_buffer_objects = false, need_handle_admin_down = false, was_admin_down = false;
 
         if (effective_speed_updated || mtu_updated)
@@ -2304,6 +2326,20 @@ task_process_status BufferMgrDynamic::handlePortTable(KeyOpFieldsValuesTuple &tu
             task_status = refreshPgsForPort(port, portInfo.effective_speed, portInfo.cable_length, portInfo.mtu);
         }
     }
+    else if (op == DEL_COMMAND)
+    {
+        if (m_portPgLookup.find(port) != m_portPgLookup.end()
+            || m_portQueueLookup.find(port) != m_portQueueLookup.end()
+            || m_portProfileListLookups[BUFFER_INGRESS].find(port) != m_portProfileListLookups[BUFFER_INGRESS].end()
+            || m_portProfileListLookups[BUFFER_EGRESS].find(port) != m_portProfileListLookups[BUFFER_EGRESS].end())
+        {
+            SWSS_LOG_NOTICE("Port %s can be removed before buffer items have been removed", port.c_str());
+            return task_process_status::task_need_retry;
+        }
+        cleanUpItemsForReclaimingBuffer(port);
+        m_portInfoLookup.erase(port);
+        SWSS_LOG_NOTICE("Port %s is removed", port.c_str());
+    }
 
     return task_status;
 }
@@ -2401,6 +2437,26 @@ task_process_status BufferMgrDynamic::handleBufferPoolTable(KeyOpFieldsValuesTup
         m_applBufferPoolTable.del(pool);
         m_stateBufferPoolTable.del(pool);
         m_bufferPoolLookup.erase(pool);
+        if (pool == INGRESS_LOSSLESS_PG_POOL_NAME)
+        {
+            m_configuredSharedHeadroomPoolSize.clear();
+        }
+
+        if (m_bufferPoolReady && m_bufferPoolLookup.empty())
+        {
+            for(auto &port : m_adminDownPorts)
+                cleanUpItemsForReclaimingBuffer(port);
+
+            // Zero profiles must be unloaded once all pools have been uploaded
+            // This can be resulted from "config qos reload"
+            // Any zero profile left can leads to buffer pool not able to be cleared
+            unloadZeroPoolAndProfiles();
+
+            m_bufferPoolReady = false;
+            m_bufferCompletelyInitialized = false;
+
+            m_pendingApplyZeroProfilePorts = m_adminDownPorts;
+        }
     }
     else
     {
@@ -2634,6 +2690,10 @@ void BufferMgrDynamic::handleSetSingleBufferObjectOnAdminDownPort(buffer_directi
     {
         if (idsToZero.empty())
         {
+            // Happens only after "config qos reload"
+            if (!m_zeroProfilesLoaded)
+                loadZeroPoolAndProfiles();
+
             // If initialization finished, no extra handle required.
             // Check whether the key overlaps with supported but not configured map
             auto const &idsToAdd = parseObjectNameFromKey(key, 1);
@@ -3125,6 +3185,20 @@ task_process_status BufferMgrDynamic::handleSingleBufferPortProfileListEntry(con
             // For admin-down ports, zero profile list has been applied on the port when it entered admin-down state
             updateBufferObjectListToDb(key, profileListLookup[port], dir);
         }
+        else
+        {
+            const auto &profileList = m_portProfileListLookups[dir][port];
+            if (!profileList.empty())
+            {
+                // Happens only after "config qos reload"
+                if (!m_zeroProfilesLoaded)
+                    loadZeroPoolAndProfiles();
+                vector<FieldValueTuple> fvVector;
+                const string &zeroProfileNameList = constructZeroProfileListFromNormalProfileList(profileList, port);
+                fvVector.emplace_back(buffer_profile_list_field_name, zeroProfileNameList);
+                m_applBufferProfileListTables[dir].set(port, fvVector);
+            }
+        }
     }
     else if (op == DEL_COMMAND)
     {
@@ -3460,6 +3534,16 @@ void BufferMgrDynamic::handlePendingBufferObjects()
             }
         }
     }
+}
+
+void BufferMgrDynamic::cleanUpItemsForReclaimingBuffer(const string &port)
+{
+    // Clean up zero buffers when the buffer pools or a port has been removed
+    if (!m_bufferObjectIdsToZero[BUFFER_PG].empty())
+        updateBufferObjectToDb(port + delimiter + m_bufferObjectIdsToZero[BUFFER_PG], "", false, BUFFER_PG);
+    if (!m_bufferObjectIdsToZero[BUFFER_QUEUE].empty())
+        updateBufferObjectToDb(port + delimiter + m_bufferObjectIdsToZero[BUFFER_QUEUE], "", false, BUFFER_QUEUE);
+    removeSupportedButNotConfiguredItemsOnPort(m_portInfoLookup[port], port);
 }
 
 void BufferMgrDynamic::doTask(SelectableTimer &timer)

--- a/cfgmgr/buffermgrdyn.h
+++ b/cfgmgr/buffermgrdyn.h
@@ -71,6 +71,7 @@ typedef struct {
     std::string xon_offset;
     std::string xoff;
     std::string threshold;
+    std::string threshold_mode;
     std::string pool_name;
     // port_pgs - stores pgs referencing this profile
     // An element will be added or removed when a PG added or removed
@@ -177,7 +178,7 @@ private:
 
     std::string m_configuredSharedHeadroomPoolSize;
 
-    std::shared_ptr<DBConnector> m_applDb = nullptr;
+    DBConnector *m_applDb = nullptr;
     SelectableTimer *m_buffermgrPeriodtimer = nullptr;
 
     // Fields for zero pool and profiles

--- a/cfgmgr/buffermgrdyn.h
+++ b/cfgmgr/buffermgrdyn.h
@@ -196,6 +196,7 @@ private:
     // key: port name
     // updated only when a port's speed and cable length updated
     port_info_lookup_t m_portInfoLookup;
+    std::map<std::string, std::string> m_cableLengths;
     std::set<std::string> m_adminDownPorts;
     std::set<std::string> m_pendingApplyZeroProfilePorts;
     std::set<std::string> m_pendingSupportedButNotConfiguredPorts[BUFFER_DIR_MAX];
@@ -302,6 +303,7 @@ private:
     void handleSetSingleBufferObjectOnAdminDownPort(buffer_direction_t direction, const std::string &port, const std::string &key, const std::string &profile);
     void handleDelSingleBufferObjectOnAdminDownPort(buffer_direction_t direction, const std::string &port, const std::string &key, port_info_t &portInfo);
     bool isReadyToReclaimBufferOnPort(const std::string &port);
+    void cleanUpItemsForReclaimingBuffer(const std::string &port);
 
     // Main flows
     template<class T> task_process_status reclaimReservedBufferForPort(const std::string &port, T &obj, buffer_direction_t dir);

--- a/cfgmgr/intfmgr.h
+++ b/cfgmgr/intfmgr.h
@@ -75,6 +75,7 @@ private:
 
     void updateSubIntfAdminStatus(const std::string &alias, const std::string &admin);
     void updateSubIntfMtu(const std::string &alias, const std::string &mtu);
+    bool enableIpv6Flag(const std::string&);
 
     bool m_replayDone {false};
 };

--- a/neighsyncd/neighsync.cpp
+++ b/neighsyncd/neighsync.cpp
@@ -79,6 +79,16 @@ void NeighSync::onMsg(int nlmsg_type, struct nl_object *obj)
     key+= ":";
 
     nl_addr2str(rtnl_neigh_get_dst(neigh), ipStr, MAX_ADDR_SIZE);
+
+    /* Ignore IPv4 link-local addresses as neighbors */
+    IpAddress ipAddress(ipStr);
+    if (family == IPV4_NAME && ipAddress.getAddrScope() == IpAddress::AddrScope::LINK_SCOPE)
+    {
+        SWSS_LOG_INFO("Link Local address received, ignoring for %s", ipStr);
+        return;
+    }
+
+
     /* Ignore IPv6 link-local addresses as neighbors, if ipv6 link local mode is disabled */
     if (family == IPV6_NAME && IN6_IS_ADDR_LINKLOCAL(nl_addr_get_binary_addr(rtnl_neigh_get_dst(neigh))))
     {

--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -113,6 +113,9 @@ typedef tuple<sai_acl_range_type_t, int, int> acl_range_properties_t;
 typedef map<acl_stage_type_t, AclActionCapabilities> acl_capabilities_t;
 typedef map<sai_acl_action_type_t, set<int32_t>> acl_action_enum_values_capabilities_t;
 
+typedef map<acl_stage_type_t, set<sai_acl_action_type_t> > acl_stage_action_list_t;
+typedef map<string, acl_stage_action_list_t> acl_table_action_list_lookup_t;
+
 class AclRule;
 
 class AclTableMatchInterface
@@ -155,6 +158,8 @@ public:
     const map<sai_acl_table_attr_t, shared_ptr<AclTableMatchInterface>>& getMatches() const;
     const set<sai_acl_range_type_t>& getRangeTypes() const;
     const set<sai_acl_action_type_t>& getActions() const;
+
+    bool addAction(sai_acl_action_type_t action);
 
 private:
     friend class AclTableTypeBuilder;
@@ -386,6 +391,9 @@ public:
     bool validateAddPorts(const unordered_set<string> &value);
     bool validate();
     bool create();
+
+    // Add actions to ACL table if mandatory action list is required on table creation.
+    bool addMandatoryActions();
 
     // validate AclRule match attribute against rule and table configuration
     bool validateAclRuleMatch(sai_acl_entry_attr_t matchId, const AclRule& rule) const;

--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -76,6 +76,7 @@ bool FdbOrch::storeFdbEntryState(const FdbUpdate& update)
     string portName = port.m_alias;
     Port vlan;
 
+    oldFdbData.origin = FDB_ORIGIN_INVALID;
     if (!m_portsOrch->getPort(entry.bv_id, vlan))
     {
         SWSS_LOG_NOTICE("FdbOrch notification: Failed to locate \

--- a/orchagent/fdborch.h
+++ b/orchagent/fdborch.h
@@ -122,6 +122,9 @@ private:
 
     bool storeFdbEntryState(const FdbUpdate& update);
     void notifyTunnelOrch(Port& port);
+
+    void clearFdbEntry(const MacAddress&, const sai_object_id_t&, const string&);
+    void handleSyncdFlushNotif(const sai_object_id_t&, const sai_object_id_t&, const MacAddress& );
 };
 
 #endif /* SWSS_FDBORCH_H */

--- a/orchagent/macsecorch.h
+++ b/orchagent/macsecorch.h
@@ -110,6 +110,7 @@ private:
         sai_object_id_t                                 m_ingress_id;
         map<std::string, std::shared_ptr<MACsecPort> >  m_macsec_ports;
         bool                                            m_sci_in_ingress_macsec_acl;
+        sai_uint8_t                                     m_max_sa_per_sc;
     };
     map<sai_object_id_t, MACsecObject>              m_macsec_objs;
     map<std::string, std::shared_ptr<MACsecPort> >  m_macsec_ports;

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -177,7 +177,7 @@ void getCfgSwitchType(DBConnector *cfgDb, string &switch_type)
         switch_type = "switch";
     }
 
-    if (switch_type != "voq" && switch_type != "fabric" && switch_type != "switch")
+    if (switch_type != "voq" && switch_type != "fabric" && switch_type != "chassis-packet" && switch_type != "switch")
     {
         SWSS_LOG_ERROR("Invalid switch type %s configured", switch_type.c_str());
     	//If configured switch type is none of the supported, assume regular switch
@@ -570,7 +570,7 @@ int main(int argc, char **argv)
     attr.value.u64 = gSwitchId;
     attrs.push_back(attr);
 
-    if (gMySwitchType == "voq" || gMySwitchType == "fabric")
+    if (gMySwitchType == "voq" || gMySwitchType == "fabric" || gMySwitchType == "chassis-packet")
     {
         /* We set this long timeout in order for orchagent to wait enough time for
          * response from syncd. It is needed since switch create takes more time
@@ -578,7 +578,7 @@ int main(int argc, char **argv)
          * and systems ports to initialize
          */
 
-        if (gMySwitchType == "voq")
+        if (gMySwitchType == "voq" || gMySwitchType == "chassis-packet")
         {
             attr.value.u64 = (5 * SAI_REDIS_DEFAULT_SYNC_OPERATION_RESPONSE_TIMEOUT);
         }
@@ -608,7 +608,7 @@ int main(int argc, char **argv)
     }
     SWSS_LOG_NOTICE("Create a switch, id:%" PRIu64, gSwitchId);
 
-    if (gMySwitchType == "voq" || gMySwitchType == "fabric")
+    if (gMySwitchType == "voq" || gMySwitchType == "fabric" || gMySwitchType == "chassis-packet")
     {
         /* Set syncd response timeout back to the default value */
         attr.id = SAI_REDIS_SWITCH_ATTR_SYNC_OPERATION_RESPONSE_TIMEOUT;

--- a/orchagent/muxorch.h
+++ b/orchagent/muxorch.h
@@ -131,6 +131,8 @@ const request_description_t mux_cfg_request_description = {
                 { "server_ipv4", REQ_T_IP_PREFIX },
                 { "server_ipv6", REQ_T_IP_PREFIX },
                 { "address_ipv4", REQ_T_IP },
+                { "soc_ipv4", REQ_T_IP_PREFIX },
+                { "cable_type", REQ_T_STRING },
             },
             { }
 };

--- a/orchagent/p4orch/tests/acl_manager_test.cpp
+++ b/orchagent/p4orch/tests/acl_manager_test.cpp
@@ -834,8 +834,6 @@ class AclManagerTest : public ::testing::Test
                                          Truly(std::bind(MatchSaiSwitchAttrByAclStage, SAI_SWITCH_ATTR_PRE_INGRESS_ACL,
                                                          kAclGroupLookupOid, std::placeholders::_1))))
             .WillRepeatedly(Return(SAI_STATUS_SUCCESS));
-        EXPECT_CALL(mock_sai_udf_, create_udf_match(_, _, _, _))
-            .WillOnce(DoAll(SetArgPointee<0>(kUdfMatchOid1), Return(SAI_STATUS_SUCCESS)));
         std::vector<std::string> p4_tables;
         gP4Orch = new P4Orch(gAppDb, p4_tables, gVrfOrch, copp_orch_);
         acl_table_manager_ = gP4Orch->getAclTableManager();
@@ -860,6 +858,8 @@ class AclManagerTest : public ::testing::Test
             .WillOnce(DoAll(SetArgPointee<0>(kAclTableIngressOid), Return(SAI_STATUS_SUCCESS)));
         EXPECT_CALL(mock_sai_acl_, create_acl_table_group_member(_, _, _, _))
             .WillOnce(DoAll(SetArgPointee<0>(kAclGroupMemberIngressOid), Return(SAI_STATUS_SUCCESS)));
+        EXPECT_CALL(mock_sai_udf_, create_udf_match(_, _, _, _))
+            .WillOnce(DoAll(SetArgPointee<0>(kUdfMatchOid1), Return(SAI_STATUS_SUCCESS)));
         EXPECT_CALL(mock_sai_udf_, create_udf_group(_, _, _, _))
             .Times(3)
             .WillRepeatedly(DoAll(SetArgPointee<0>(kUdfGroupOid1), Return(SAI_STATUS_SUCCESS)));
@@ -1156,6 +1156,8 @@ TEST_F(AclManagerTest, CreateIngressPuntTableFailsWhenCapabilityExceeds)
     auto app_db_entry = getDefaultAclTableDefAppDbEntry();
     sai_object_id_t user_defined_trap_oid = gUserDefinedTrapStartOid;
     AddDefaultUserTrapsSaiCalls(&user_defined_trap_oid);
+    EXPECT_CALL(mock_sai_udf_, create_udf_match(_, _, _, _))
+        .WillOnce(DoAll(SetArgPointee<0>(kUdfMatchOid1), Return(SAI_STATUS_SUCCESS)));
     EXPECT_CALL(mock_sai_udf_, create_udf_group(_, _, _, _))
         .WillRepeatedly(DoAll(SetArgPointee<0>(kUdfGroupOid1), Return(SAI_STATUS_SUCCESS)));
     EXPECT_CALL(mock_sai_udf_, create_udf(_, _, _, _)).Times(3).WillRepeatedly(Return(SAI_STATUS_SUCCESS));
@@ -1170,6 +1172,8 @@ TEST_F(AclManagerTest, CreateIngressPuntTableFailsWhenFailedToCreateTableGroupMe
     auto app_db_entry = getDefaultAclTableDefAppDbEntry();
     sai_object_id_t user_defined_trap_oid = gUserDefinedTrapStartOid;
     AddDefaultUserTrapsSaiCalls(&user_defined_trap_oid);
+    EXPECT_CALL(mock_sai_udf_, create_udf_match(_, _, _, _))
+        .WillOnce(DoAll(SetArgPointee<0>(kUdfMatchOid1), Return(SAI_STATUS_SUCCESS)));
     EXPECT_CALL(mock_sai_udf_, create_udf_group(_, _, _, _))
         .WillRepeatedly(DoAll(SetArgPointee<0>(kUdfGroupOid1), Return(SAI_STATUS_SUCCESS)));
     EXPECT_CALL(mock_sai_udf_, create_udf(_, _, _, _)).Times(3).WillRepeatedly(Return(SAI_STATUS_SUCCESS));
@@ -1187,6 +1191,8 @@ TEST_F(AclManagerTest, CreateIngressPuntTableRaisesCriticalStateWhenAclTableReco
     auto app_db_entry = getDefaultAclTableDefAppDbEntry();
     sai_object_id_t user_defined_trap_oid = gUserDefinedTrapStartOid;
     AddDefaultUserTrapsSaiCalls(&user_defined_trap_oid);
+    EXPECT_CALL(mock_sai_udf_, create_udf_match(_, _, _, _))
+        .WillOnce(DoAll(SetArgPointee<0>(kUdfMatchOid1), Return(SAI_STATUS_SUCCESS)));
     EXPECT_CALL(mock_sai_udf_, create_udf_group(_, _, _, _))
         .WillRepeatedly(DoAll(SetArgPointee<0>(kUdfGroupOid1), Return(SAI_STATUS_SUCCESS)));
     EXPECT_CALL(mock_sai_udf_, create_udf(_, _, _, _)).Times(3).WillRepeatedly(Return(SAI_STATUS_SUCCESS));
@@ -1205,6 +1211,8 @@ TEST_F(AclManagerTest, CreateIngressPuntTableRaisesCriticalStateWhenUdfGroupReco
     auto app_db_entry = getDefaultAclTableDefAppDbEntry();
     sai_object_id_t user_defined_trap_oid = gUserDefinedTrapStartOid;
     AddDefaultUserTrapsSaiCalls(&user_defined_trap_oid);
+    EXPECT_CALL(mock_sai_udf_, create_udf_match(_, _, _, _))
+        .WillOnce(DoAll(SetArgPointee<0>(kUdfMatchOid1), Return(SAI_STATUS_SUCCESS)));
     EXPECT_CALL(mock_sai_udf_, create_udf_group(_, _, _, _))
         .WillRepeatedly(DoAll(SetArgPointee<0>(kUdfGroupOid1), Return(SAI_STATUS_SUCCESS)));
     EXPECT_CALL(mock_sai_udf_, create_udf(_, _, _, _)).Times(3).WillRepeatedly(Return(SAI_STATUS_SUCCESS));
@@ -1223,6 +1231,8 @@ TEST_F(AclManagerTest, CreateIngressPuntTableRaisesCriticalStateWhenUdfRecoveryF
     auto app_db_entry = getDefaultAclTableDefAppDbEntry();
     sai_object_id_t user_defined_trap_oid = gUserDefinedTrapStartOid;
     AddDefaultUserTrapsSaiCalls(&user_defined_trap_oid);
+    EXPECT_CALL(mock_sai_udf_, create_udf_match(_, _, _, _))
+        .WillOnce(DoAll(SetArgPointee<0>(kUdfMatchOid1), Return(SAI_STATUS_SUCCESS)));
     EXPECT_CALL(mock_sai_udf_, create_udf_group(_, _, _, _))
         .WillRepeatedly(DoAll(SetArgPointee<0>(kUdfGroupOid1), Return(SAI_STATUS_SUCCESS)));
     EXPECT_CALL(mock_sai_udf_, create_udf(_, _, _, _)).Times(3).WillRepeatedly(Return(SAI_STATUS_SUCCESS));
@@ -1244,6 +1254,8 @@ TEST_F(AclManagerTest, CreateIngressPuntTableFailsWhenFailedToCreateUdf)
     AddDefaultUserTrapsSaiCalls(&user_defined_trap_oid);
     // Fail to create the first UDF, and success to remove the first UDF
     // group
+    EXPECT_CALL(mock_sai_udf_, create_udf_match(_, _, _, _))
+        .WillOnce(DoAll(SetArgPointee<0>(kUdfMatchOid1), Return(SAI_STATUS_SUCCESS)));
     EXPECT_CALL(mock_sai_udf_, create_udf_group(_, _, _, _)).WillOnce(Return(SAI_STATUS_SUCCESS));
     EXPECT_CALL(mock_sai_udf_, create_udf(_, _, _, _)).WillOnce(Return(SAI_STATUS_FAILURE));
     EXPECT_CALL(mock_sai_udf_, remove_udf_group(_)).WillOnce(Return(SAI_STATUS_SUCCESS));
@@ -2099,6 +2111,8 @@ TEST_F(AclManagerTest, DrainRuleTuplesToProcessSetRequestSucceeds)
         .WillOnce(DoAll(SetArgPointee<0>(kAclTableIngressOid), Return(SAI_STATUS_SUCCESS)));
     EXPECT_CALL(mock_sai_acl_, create_acl_table_group_member(_, _, _, _))
         .WillOnce(DoAll(SetArgPointee<0>(kAclGroupMemberIngressOid), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_CALL(mock_sai_udf_, create_udf_match(_, _, _, _))
+        .WillOnce(DoAll(SetArgPointee<0>(kUdfMatchOid1), Return(SAI_STATUS_SUCCESS)));
     EXPECT_CALL(mock_sai_udf_, create_udf_group(_, _, _, _))
         .WillRepeatedly(DoAll(SetArgPointee<0>(kUdfGroupOid1), Return(SAI_STATUS_SUCCESS)));
     EXPECT_CALL(mock_sai_udf_, create_udf(_, _, _, _)).Times(3).WillRepeatedly(Return(SAI_STATUS_SUCCESS));
@@ -4055,6 +4069,8 @@ TEST_F(AclManagerTest, DoAclCounterStatsTaskSucceeds)
         .WillOnce(DoAll(SetArgPointee<0>(kAclTableIngressOid), Return(SAI_STATUS_SUCCESS)));
     EXPECT_CALL(mock_sai_acl_, create_acl_table_group_member(_, _, _, _))
         .WillOnce(DoAll(SetArgPointee<0>(kAclGroupMemberIngressOid), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_CALL(mock_sai_udf_, create_udf_match(_, _, _, _))
+        .WillOnce(DoAll(SetArgPointee<0>(kUdfMatchOid1), Return(SAI_STATUS_SUCCESS)));
     EXPECT_CALL(mock_sai_udf_, create_udf_group(_, _, _, _))
         .WillRepeatedly(DoAll(SetArgPointee<0>(kUdfGroupOid1), Return(SAI_STATUS_SUCCESS)));
     EXPECT_CALL(mock_sai_udf_, create_udf(_, _, _, _)).Times(3).WillRepeatedly(Return(SAI_STATUS_SUCCESS));

--- a/orchagent/p4orch/tests/wcmp_manager_test.cpp
+++ b/orchagent/p4orch/tests/wcmp_manager_test.cpp
@@ -12,7 +12,6 @@
 #include "mock_sai_next_hop_group.h"
 #include "mock_sai_serialize.h"
 #include "mock_sai_switch.h"
-#include "mock_sai_udf.h"
 #include "p4oidmapper.h"
 #include "p4orch.h"
 #include "p4orch/p4orch_util.h"
@@ -31,7 +30,6 @@ extern sai_object_id_t gSwitchId;
 extern sai_next_hop_group_api_t *sai_next_hop_group_api;
 extern sai_hostif_api_t *sai_hostif_api;
 extern sai_switch_api_t *sai_switch_api;
-extern sai_udf_api_t *sai_udf_api;
 extern sai_object_id_t gSwitchId;
 extern sai_acl_api_t *sai_acl_api;
 
@@ -68,7 +66,6 @@ const std::string kWcmpGroupKey1 = KeyGenerator::generateWcmpGroupKey(kWcmpGroup
 const std::string kNexthopKey1 = KeyGenerator::generateNextHopKey(kNexthopId1);
 const std::string kNexthopKey2 = KeyGenerator::generateNextHopKey(kNexthopId2);
 const std::string kNexthopKey3 = KeyGenerator::generateNextHopKey(kNexthopId3);
-constexpr sai_object_id_t kUdfMatchOid1 = 5001;
 
 // Matches the next hop group type sai_attribute_t argument.
 bool MatchSaiNextHopGroupAttribute(const sai_attribute_t *attr)
@@ -154,7 +151,6 @@ class WcmpManagerTest : public ::testing::Test
         EXPECT_CALL(mock_sai_switch_, set_switch_attribute(Eq(gSwitchId), _))
             .WillRepeatedly(Return(SAI_STATUS_SUCCESS));
         EXPECT_CALL(mock_sai_acl_, remove_acl_table_group(_)).WillRepeatedly(Return(SAI_STATUS_SUCCESS));
-        EXPECT_CALL(mock_sai_udf_, remove_udf_match(_)).WillRepeatedly(Return(SAI_STATUS_SUCCESS));
         delete gP4Orch;
         delete copp_orch_;
     }
@@ -167,7 +163,6 @@ class WcmpManagerTest : public ::testing::Test
         mock_sai_hostif = &mock_sai_hostif_;
         mock_sai_serialize = &mock_sai_serialize_;
         mock_sai_acl = &mock_sai_acl_;
-        mock_sai_udf = &mock_sai_udf_;
 
         sai_next_hop_group_api->create_next_hop_group = create_next_hop_group;
         sai_next_hop_group_api->remove_next_hop_group = remove_next_hop_group;
@@ -181,8 +176,6 @@ class WcmpManagerTest : public ::testing::Test
         sai_switch_api->set_switch_attribute = mock_set_switch_attribute;
         sai_acl_api->create_acl_table_group = create_acl_table_group;
         sai_acl_api->remove_acl_table_group = remove_acl_table_group;
-        sai_udf_api->create_udf_match = create_udf_match;
-        sai_udf_api->remove_udf_match = remove_udf_match;
     }
 
     void setUpP4Orch()
@@ -194,9 +187,6 @@ class WcmpManagerTest : public ::testing::Test
         copp_orch_ = new CoppOrch(gAppDb, APP_COPP_TABLE_NAME);
 
         // init P4 orch
-        EXPECT_CALL(mock_sai_udf_, create_udf_match(_, _, _, _))
-            .WillOnce(DoAll(SetArgPointee<0>(kUdfMatchOid1), Return(SAI_STATUS_SUCCESS)));
-
         std::vector<std::string> p4_tables;
         gP4Orch = new P4Orch(gAppDb, p4_tables, gVrfOrch, copp_orch_);
     }
@@ -301,7 +291,6 @@ class WcmpManagerTest : public ::testing::Test
     StrictMock<MockSaiHostif> mock_sai_hostif_;
     StrictMock<MockSaiSerialize> mock_sai_serialize_;
     StrictMock<MockSaiAcl> mock_sai_acl_;
-    StrictMock<MockSaiUdf> mock_sai_udf_;
     P4OidMapper *p4_oid_mapper_;
     WcmpManager *wcmp_group_manager_;
     CoppOrch *copp_orch_;

--- a/orchagent/policerorch.cpp
+++ b/orchagent/policerorch.cpp
@@ -8,9 +8,12 @@ using namespace std;
 using namespace swss;
 
 extern sai_policer_api_t*   sai_policer_api;
+extern sai_port_api_t *sai_port_api;
 
 extern sai_object_id_t gSwitchId;
 extern PortsOrch* gPortsOrch;
+
+#define ETHERNET_PREFIX "Ethernet"
 
 static const string meter_type_field           = "METER_TYPE";
 static const string mode_field                 = "MODE";
@@ -22,6 +25,11 @@ static const string pir_field                  = "PIR";
 static const string green_packet_action_field  = "GREEN_PACKET_ACTION";
 static const string red_packet_action_field    = "RED_PACKET_ACTION";
 static const string yellow_packet_action_field = "YELLOW_PACKET_ACTION";
+
+static const string storm_control_kbps         = "KBPS";
+static const string storm_broadcast            = "broadcast";
+static const string storm_unknown_unicast      = "unknown-unicast";
+static const string storm_unknown_mcast        = "unknown-multicast";
 
 static const map<string, sai_meter_type_t> meter_type_map = {
     {"PACKETS", SAI_METER_TYPE_PACKETS},
@@ -105,15 +113,268 @@ bool PolicerOrch::decreaseRefCount(const string &name)
     return true;
 }
 
-PolicerOrch::PolicerOrch(DBConnector* db, string tableName) :
-    Orch(db, tableName)
+PolicerOrch::PolicerOrch(vector<TableConnector> &tableNames, PortsOrch *portOrch) : Orch(tableNames), m_portsOrch(portOrch)
 {
     SWSS_LOG_ENTER();
+}
+
+task_process_status PolicerOrch::handlePortStormControlTable(swss::KeyOpFieldsValuesTuple tuple)
+{
+    auto key = kfvKey(tuple);
+    auto op = kfvOp(tuple);
+    string storm_key = key;
+    auto tokens = tokenize(storm_key, config_db_key_delimiter);
+    auto interface_name = tokens[0];
+    auto storm_type = tokens[1];
+    Port port;
+
+    /*Only proceed for Ethernet interfaces*/
+    if (strncmp(interface_name.c_str(), ETHERNET_PREFIX, strlen(ETHERNET_PREFIX)))
+    {
+        SWSS_LOG_ERROR("%s: Unsupported / Invalid interface %s",
+                storm_type.c_str(), interface_name.c_str());
+        return task_process_status::task_success;
+    }
+    if (!gPortsOrch->getPort(interface_name, port))
+    {
+        SWSS_LOG_ERROR("Failed to apply storm-control %s to port %s. Port not found",
+                storm_type.c_str(), interface_name.c_str());
+        /*continue here as there can be more interfaces*/
+        return task_process_status::task_success;
+    }
+    /*Policer Name: _<interface_name>_<storm_type>*/
+    const auto storm_policer_name = "_"+interface_name+"_"+storm_type;
+
+    if (op == SET_COMMAND)
+    {
+        // Mark the operation as an 'update', if the policer exists.
+        bool update = m_syncdPolicers.find(storm_policer_name) != m_syncdPolicers.end();
+        vector <sai_attribute_t> attrs;
+        bool cir = false;
+        sai_attribute_t attr;
+
+        /*Meter type hardcoded to BYTES*/
+        attr.id = SAI_POLICER_ATTR_METER_TYPE;
+        attr.value.s32 = (sai_meter_type_t) meter_type_map.at("BYTES");
+        attrs.push_back(attr);
+
+        /*Policer mode hardcoded to STORM_CONTROL*/
+        attr.id = SAI_POLICER_ATTR_MODE;
+        attr.value.s32 = (sai_policer_mode_t) policer_mode_map.at("STORM_CONTROL");
+        attrs.push_back(attr);
+
+        /*Red Packet Action hardcoded to DROP*/
+        attr.id = SAI_POLICER_ATTR_RED_PACKET_ACTION;
+        attr.value.s32 = packet_action_map.at("DROP");
+        attrs.push_back(attr);
+
+        for (auto i = kfvFieldsValues(tuple).begin();
+                i != kfvFieldsValues(tuple).end(); ++i)
+        {
+            auto field = to_upper(fvField(*i));
+            auto value = to_upper(fvValue(*i));
+
+            /*BPS value is used as CIR*/
+            if (field == storm_control_kbps)
+            {
+                attr.id = SAI_POLICER_ATTR_CIR;
+                /*convert kbps to bps*/
+                attr.value.u64 = (stoul(value)*1000/8);
+                cir = true;
+                attrs.push_back(attr);
+                SWSS_LOG_DEBUG("CIR %s",value.c_str());
+            }
+            else
+            {
+                SWSS_LOG_ERROR("Unknown storm control attribute %s specified",
+                        field.c_str());
+                continue;
+            }
+        }
+        /*CIR is mandatory parameter*/
+        if (!cir)
+        {
+            SWSS_LOG_ERROR("Failed to create storm control policer %s,\
+                    missing mandatory fields", storm_policer_name.c_str());
+            return task_process_status::task_failed;
+        }
+
+        /*Enabling storm-control on port*/
+        sai_attribute_t port_attr;
+        if (storm_type == storm_broadcast)
+        {
+            port_attr.id = SAI_PORT_ATTR_BROADCAST_STORM_CONTROL_POLICER_ID;
+        }
+        else if (storm_type == storm_unknown_unicast)
+        {
+            port_attr.id = SAI_PORT_ATTR_FLOOD_STORM_CONTROL_POLICER_ID;
+        }
+        else if (storm_type == storm_unknown_mcast)
+        {
+            port_attr.id = SAI_PORT_ATTR_MULTICAST_STORM_CONTROL_POLICER_ID;
+        }
+        else
+        {
+            SWSS_LOG_ERROR("Unknown storm_type %s", storm_type.c_str());
+            return task_process_status::task_failed;
+        }
+
+        sai_object_id_t policer_id;
+        // Create a new policer
+        if (!update)
+        {
+            sai_status_t status = sai_policer_api->create_policer(
+                    &policer_id, gSwitchId, (uint32_t)attrs.size(), attrs.data());
+            if (status != SAI_STATUS_SUCCESS)
+            {
+                SWSS_LOG_ERROR("Failed to create policer %s, rv:%d",
+                        storm_policer_name.c_str(), status);
+                if (handleSaiCreateStatus(SAI_API_POLICER, status) == task_need_retry)
+                {
+                    return task_process_status::task_need_retry;
+                }
+            }
+
+            SWSS_LOG_DEBUG("Created storm-control policer %s", storm_policer_name.c_str());
+            m_syncdPolicers[storm_policer_name] = policer_id;
+            m_policerRefCounts[storm_policer_name] = 0;
+        }
+        // Update an existing policer
+        else
+        {
+            policer_id = m_syncdPolicers[storm_policer_name];
+
+            // The update operation has limitations that it could only update
+            // the rate and the size accordingly.
+            // STORM_CONTROL: CIR, CBS
+            for (auto & attr: attrs)
+            {
+                if (attr.id != SAI_POLICER_ATTR_CIR)
+                {
+                    continue;
+                }
+
+                sai_status_t status = sai_policer_api->set_policer_attribute(
+                        policer_id, &attr);
+                if (status != SAI_STATUS_SUCCESS)
+                {
+                    SWSS_LOG_ERROR("Failed to update policer %s attribute, rv:%d",
+                            storm_policer_name.c_str(), status);
+                    if (handleSaiSetStatus(SAI_API_POLICER, status) == task_need_retry)
+                    {
+                        return task_process_status::task_need_retry;
+                    }
+
+                }
+            }
+        }
+        policer_id = m_syncdPolicers[storm_policer_name];
+
+        if (update)
+        {
+            SWSS_LOG_NOTICE("update storm-control policer %s", storm_policer_name.c_str());
+            port_attr.value.oid = SAI_NULL_OBJECT_ID;
+            /*Remove and re-apply policer*/
+            sai_status_t status = sai_port_api->set_port_attribute(port.m_port_id, &port_attr);
+            if (status != SAI_STATUS_SUCCESS)
+            {
+                SWSS_LOG_ERROR("Failed to remove storm-control %s from port %s, rv:%d",
+                        storm_type.c_str(), interface_name.c_str(), status);
+                if (handleSaiSetStatus(SAI_API_POLICER, status) == task_need_retry)
+                {
+                    return task_process_status::task_need_retry;
+                }
+            }
+        }
+        port_attr.value.oid = policer_id;
+
+        sai_status_t status = sai_port_api->set_port_attribute(port.m_port_id, &port_attr);
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("Failed to apply storm-control %s to port %s, rv:%d",
+                    storm_type.c_str(), interface_name.c_str(),status);
+
+            /*TODO: Do the below policer cleanup in an API*/
+            /*Remove the already created policer*/
+            if (SAI_STATUS_SUCCESS != sai_policer_api->remove_policer(
+                        m_syncdPolicers[storm_policer_name]))
+            {
+                SWSS_LOG_ERROR("Failed to remove policer %s, rv:%d",
+                        storm_policer_name.c_str(), status);
+                /*TODO: Just doing a syslog. */
+            }
+
+            SWSS_LOG_NOTICE("Removed policer %s as set_port_attribute for %s failed", 
+                    storm_policer_name.c_str(),interface_name.c_str());
+            m_syncdPolicers.erase(storm_policer_name);
+            m_policerRefCounts.erase(storm_policer_name);
+
+            return task_process_status::task_need_retry;
+        }
+    }
+    else if (op == DEL_COMMAND)
+    {
+        if (m_syncdPolicers.find(storm_policer_name) == m_syncdPolicers.end())
+        {
+            SWSS_LOG_ERROR("Policer %s not configured", storm_policer_name.c_str());
+            return task_process_status::task_success;
+        }
+
+        sai_attribute_t port_attr;
+        if (storm_type == storm_broadcast)
+        {
+            port_attr.id = SAI_PORT_ATTR_BROADCAST_STORM_CONTROL_POLICER_ID;
+        }
+        else if (storm_type == storm_unknown_unicast)
+        {
+            port_attr.id = SAI_PORT_ATTR_FLOOD_STORM_CONTROL_POLICER_ID;
+        }
+        else if (storm_type == storm_unknown_mcast)
+        {
+            port_attr.id = SAI_PORT_ATTR_MULTICAST_STORM_CONTROL_POLICER_ID;
+        }
+        else
+        {
+            SWSS_LOG_ERROR("Unknown storm_type %s", storm_type.c_str());
+            return task_process_status::task_failed;
+        }
+
+        port_attr.value.oid = SAI_NULL_OBJECT_ID;
+
+        sai_status_t status = sai_port_api->set_port_attribute(port.m_port_id, &port_attr);
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("Failed to remove storm-control %s from port %s, rv:%d",
+                    storm_type.c_str(), interface_name.c_str(), status);
+            if (handleSaiRemoveStatus(SAI_API_POLICER, status) == task_need_retry)
+            {
+                return task_process_status::task_need_retry;
+            }
+        }
+
+        status = sai_policer_api->remove_policer(
+                m_syncdPolicers[storm_policer_name]);
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("Failed to remove policer %s, rv:%d",
+                    storm_policer_name.c_str(), status);
+            if (handleSaiRemoveStatus(SAI_API_POLICER, status) == task_need_retry)
+            {
+                return task_process_status::task_need_retry;
+            }
+        }
+
+        SWSS_LOG_NOTICE("Removed policer %s", storm_policer_name.c_str());
+        m_syncdPolicers.erase(storm_policer_name);
+        m_policerRefCounts.erase(storm_policer_name);
+    }
+    return task_process_status::task_success;
 }
 
 void PolicerOrch::doTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
+    task_process_status storm_status = task_success;
 
     if (!gPortsOrch->allPortsReady())
     {
@@ -127,7 +388,23 @@ void PolicerOrch::doTask(Consumer &consumer)
 
         auto key = kfvKey(tuple);
         auto op = kfvOp(tuple);
+        auto table_name = consumer.getTableName();
 
+        // Special handling for storm-control configuration.
+        if (table_name == CFG_PORT_STORM_CONTROL_TABLE_NAME)
+        {
+            storm_status = handlePortStormControlTable(tuple);
+            if ((storm_status == task_process_status::task_success) ||
+                    (storm_status == task_process_status::task_failed))
+            {
+                it = consumer.m_toSync.erase(it);
+            }
+            else
+            {
+                it++;
+            }
+            continue;
+        }
         if (op == SET_COMMAND)
         {
             // Mark the operation as an 'update', if the policer exists.

--- a/orchagent/policerorch.h
+++ b/orchagent/policerorch.h
@@ -14,16 +14,20 @@ typedef map<string, int> PolicerRefCountTable;
 class PolicerOrch : public Orch
 {
 public:
-    PolicerOrch(DBConnector* db, string tableName);
+    PolicerOrch(vector<TableConnector> &tableNames, PortsOrch *portOrch);
 
     bool policerExists(const string &name);
     bool getPolicerOid(const string &name, sai_object_id_t &oid);
 
     bool increaseRefCount(const string &name);
     bool decreaseRefCount(const string &name);
+    task_process_status handlePortStormControlTable(swss::KeyOpFieldsValuesTuple tuple);
 private:
+    PortsOrch *m_portsOrch;
     virtual void doTask(Consumer& consumer);
 
     PolicerTable m_syncdPolicers;
     PolicerRefCountTable m_policerRefCounts;
 };
+
+

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4573,9 +4573,10 @@ bool PortsOrch::removeVlan(Port vlan)
        return false for retry */
     if (vlan.m_fdb_count > 0)
     {
-        SWSS_LOG_NOTICE("VLAN %s still has assiciated FDB entries", vlan.m_alias.c_str());
+        SWSS_LOG_NOTICE("VLAN %s still has %d FDB entries", vlan.m_alias.c_str(), vlan.m_fdb_count);
         return false;
     }
+
     if (m_port_ref_count[vlan.m_alias] > 0)
     {
         SWSS_LOG_ERROR("Failed to remove ref count %d VLAN %s",
@@ -6927,4 +6928,18 @@ std::unordered_set<std::string> PortsOrch::generateCounterStats(const string& ty
         }
     }
     return counter_stats;
+}
+
+bool PortsOrch::decrFdbCount(const std::string& alias, int count)
+{
+    auto itr = m_portList.find(alias);
+    if (itr == m_portList.end())
+    {
+        return false;
+    }
+    else
+    {
+        itr->second.m_fdb_count -= count;
+    }
+    return true;
 }

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -168,6 +168,7 @@ public:
 
     bool getPortOperStatus(const Port& port, sai_port_oper_status_t& status) const;
 
+    bool decrFdbCount(const string& alias, int count);
 private:
     unique_ptr<Table> m_counterTable;
     unique_ptr<Table> m_counterLagTable;

--- a/portsyncd/linksync.cpp
+++ b/portsyncd/linksync.cpp
@@ -205,10 +205,9 @@ void LinkSync::onMsg(int nlmsg_type, struct nl_object *obj)
         return;
     }
 
-    /* If netlink for this port has master, we ignore that for now
-     * This could be the case where the port was removed from VLAN bridge
-     */
-    if (master)
+    /* Ignore DELLINK message if port has master, this is applicable to
+     * the case where port was part of VLAN bridge or LAG */
+    if (master && nlmsg_type == RTM_DELLINK)
     {
         return;
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1196,6 +1196,94 @@ class DockerVirtualSwitch:
         fvs = swsscommon.FieldValuePairs([("enable",enable)])
         tbl.set("swss", fvs)
 
+    # nat
+    def nat_mode_set(self, value):
+        cdb = swsscommon.DBConnector(4, self.redis_sock, 0)
+        tbl = swsscommon.Table(cdb, "NAT_GLOBAL")
+        fvs = swsscommon.FieldValuePairs([("admin_mode", value)])
+        tbl.set("Values", fvs)
+        time.sleep(1)
+
+    def nat_timeout_set(self, value):
+        cdb = swsscommon.DBConnector(4, self.redis_sock, 0)
+        tbl = swsscommon.Table(cdb, "NAT_GLOBAL")
+        fvs = swsscommon.FieldValuePairs([("nat_timeout", value)])
+        tbl.set("Values", fvs)
+        time.sleep(1)
+
+    def nat_udp_timeout_set(self, value):
+        cdb = swsscommon.DBConnector(4, self.redis_sock, 0)
+        tbl = swsscommon.Table(cdb, "NAT_GLOBAL")
+        fvs = swsscommon.FieldValuePairs([("nat_udp_timeout", value)])
+        tbl.set("Values", fvs)
+        time.sleep(1)
+
+    def nat_tcp_timeout_set(self, value):
+        cdb = swsscommon.DBConnector(4, self.redis_sock, 0)
+        tbl = swsscommon.Table(cdb, "NAT_GLOBAL")
+        fvs = swsscommon.FieldValuePairs([("nat_tcp_timeout", value)])
+        tbl.set("Values", fvs)
+        time.sleep(1)
+
+    def add_nat_basic_entry(self, external, internal):
+        cdb = swsscommon.DBConnector(4, self.redis_sock, 0)
+        tbl = swsscommon.Table(cdb, "STATIC_NAT")
+        fvs = swsscommon.FieldValuePairs([("local_ip", internal)])
+        tbl.set(external, fvs)
+        time.sleep(1)
+
+    def del_nat_basic_entry(self, external):
+        cdb = swsscommon.DBConnector(4, self.redis_sock, 0)
+        tbl = swsscommon.Table(cdb, "STATIC_NAT")
+        tbl._del(external)
+        time.sleep(1)
+
+    def add_nat_udp_entry(self, external, extport, internal, intport):
+        cdb = swsscommon.DBConnector(4, self.redis_sock, 0)
+        tbl = swsscommon.Table(cdb, "STATIC_NAPT")
+        fvs = swsscommon.FieldValuePairs([("local_ip", internal), ("local_port", intport)])
+        tbl.set(external + "|UDP|" + extport, fvs)
+        time.sleep(1)
+
+    def del_nat_udp_entry(self, external, extport):
+        cdb = swsscommon.DBConnector(4, self.redis_sock, 0)
+        tbl = swsscommon.Table(cdb, "STATIC_NAPT")
+        tbl._del(external + "|UDP|" + extport)
+        time.sleep(1)
+
+    def add_twice_nat_basic_entry(self, external, internal, nat_type, twice_nat_id):
+        cdb = swsscommon.DBConnector(4, self.redis_sock, 0)
+        tbl = swsscommon.Table(cdb, "STATIC_NAT")
+        fvs = swsscommon.FieldValuePairs([("local_ip", internal), ("nat_type", nat_type), ("twice_nat_id", twice_nat_id)])
+        tbl.set(external, fvs)
+        time.sleep(1)
+
+    def del_twice_nat_basic_entry(self, external):
+        self.del_nat_basic_entry(external)
+
+    def add_twice_nat_udp_entry(self, external, extport, internal, intport, nat_type, twice_nat_id):
+        cdb = swsscommon.DBConnector(4, self.redis_sock, 0)
+        tbl = swsscommon.Table(cdb, "STATIC_NAPT")
+        fvs = swsscommon.FieldValuePairs([("local_ip", internal), ("local_port", intport), ("nat_type", nat_type), ("twice_nat_id", twice_nat_id)])
+        tbl.set(external + "|UDP|" + extport, fvs)
+        time.sleep(1)
+
+    def del_twice_nat_udp_entry(self, external, extport):
+        self.del_nat_udp_entry(external, extport)
+
+    def set_nat_zone(self, interface, nat_zone):
+        cdb = swsscommon.DBConnector(4, self.redis_sock, 0)
+        if interface.startswith("PortChannel"):
+            tbl_name = "PORTCHANNEL_INTERFACE"
+        elif interface.startswith("Vlan"):
+            tbl_name = "VLAN_INTERFACE"
+        else:
+            tbl_name = "INTERFACE"
+        tbl = swsscommon.Table(cdb, tbl_name)
+        fvs = swsscommon.FieldValuePairs([("nat_zone", nat_zone)])
+        tbl.set(interface, fvs)
+        time.sleep(1)
+
     # deps: acl, crm, fdb
     def setReadOnlyAttr(self, obj, attr, val):
         db = swsscommon.DBConnector(swsscommon.ASIC_DB, self.redis_sock, 0)

--- a/tests/dvslib/dvs_common.py
+++ b/tests/dvslib/dvs_common.py
@@ -17,7 +17,7 @@ class PollingConfig:
     """
 
     polling_interval: float = 0.01
-    timeout: float = 5.00
+    timeout: float = 20.00
     strict: bool = True
 
     def iterations(self) -> int:

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -6,9 +6,9 @@ INCLUDES = -I $(FLEX_CTR_DIR) -I $(DEBUG_CTR_DIR) -I $(top_srcdir)/lib
 
 CFLAGS_SAI = -I /usr/include/sai
 
-TESTS = tests
+TESTS = tests tests_intfmgrd
 
-noinst_PROGRAMS = tests
+noinst_PROGRAMS = tests tests_intfmgrd
 
 LDADD_SAI = -lsaimeta -lsaimetadata -lsaivs -lsairedis
 
@@ -115,3 +115,22 @@ tests_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAG
 tests_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) -I$(top_srcdir)/orchagent
 tests_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhiredis -lhiredis -lpthread \
         -lswsscommon -lswsscommon -lgtest -lgtest_main -lzmq -lnl-3 -lnl-route-3
+
+## intfmgrd unit tests
+
+tests_intfmgrd_SOURCES = intfmgrd/add_ipv6_prefix_ut.cpp \
+                        $(top_srcdir)/cfgmgr/intfmgr.cpp \
+                        $(top_srcdir)/orchagent/orch.cpp \
+                        $(top_srcdir)/orchagent/request_parser.cpp \
+                        $(top_srcdir)/lib/subintf.cpp \
+                        mock_orchagent_main.cpp \
+                        mock_dbconnector.cpp \
+                        mock_table.cpp \
+                        mock_hiredis.cpp \
+                        fake_response_publisher.cpp \
+                        mock_redisreply.cpp
+
+tests_intfmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI)
+tests_intfmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) -I $(top_srcdir)/cfgmgr -I $(top_srcdir)/orchagent/
+tests_intfmgrd_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhiredis -lhiredis \
+        -lswsscommon -lswsscommon -lgtest -lgtest_main -lzmq -lnl-3 -lnl-route-3 -lpthread

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -26,6 +26,7 @@ tests_SOURCES = aclorch_ut.cpp \
                 routeorch_ut.cpp \
                 qosorch_ut.cpp \
                 bufferorch_ut.cpp \
+                fdborch/flush_syncd_notif_ut.cpp \
                 copporch_ut.cpp \
                 saispy_ut.cpp \
                 consumer_ut.cpp \

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -2,7 +2,7 @@ FLEX_CTR_DIR = $(top_srcdir)/orchagent/flex_counter
 DEBUG_CTR_DIR = $(top_srcdir)/orchagent/debug_counter
 P4_ORCH_DIR = $(top_srcdir)/orchagent/p4orch
 
-INCLUDES = -I $(FLEX_CTR_DIR) -I $(DEBUG_CTR_DIR) -I $(top_srcdir)/lib
+INCLUDES = -I $(FLEX_CTR_DIR) -I $(DEBUG_CTR_DIR) -I $(top_srcdir)/lib -I $(top_srcdir)/cfgmgr
 
 CFLAGS_SAI = -I /usr/include/sai
 
@@ -26,6 +26,7 @@ tests_SOURCES = aclorch_ut.cpp \
                 routeorch_ut.cpp \
                 qosorch_ut.cpp \
                 bufferorch_ut.cpp \
+                buffermgrdyn_ut.cpp \
                 fdborch/flush_syncd_notif_ut.cpp \
                 copporch_ut.cpp \
                 saispy_ut.cpp \
@@ -95,7 +96,8 @@ tests_SOURCES = aclorch_ut.cpp \
                 $(top_srcdir)/orchagent/lagid.cpp \
                 $(top_srcdir)/orchagent/bfdorch.cpp \
                 $(top_srcdir)/orchagent/srv6orch.cpp \
-                $(top_srcdir)/orchagent/nvgreorch.cpp
+                $(top_srcdir)/orchagent/nvgreorch.cpp \
+                $(top_srcdir)/cfgmgr/buffermgrdyn.cpp
 
 tests_SOURCES += $(FLEX_CTR_DIR)/flex_counter_manager.cpp $(FLEX_CTR_DIR)/flex_counter_stat_manager.cpp $(FLEX_CTR_DIR)/flow_counter_handler.cpp $(FLEX_CTR_DIR)/flowcounterrouteorch.cpp
 tests_SOURCES += $(DEBUG_CTR_DIR)/debug_counter.cpp $(DEBUG_CTR_DIR)/drop_counter.cpp

--- a/tests/mock_tests/aclorch_ut.cpp
+++ b/tests/mock_tests/aclorch_ut.cpp
@@ -1755,4 +1755,96 @@ namespace aclorch_test
         // try to delete non existing acl rule
         ASSERT_TRUE(orch->m_aclOrch->removeAclRule(tableId, ruleId));
     }
+
+    sai_switch_api_t *old_sai_switch_api;
+
+    // The following function is used to override SAI API get_switch_attribute to request passing
+    // mandatory ACL actions to SAI when creating mirror ACL table.
+    sai_status_t getSwitchAttribute(_In_ sai_object_id_t switch_id,_In_ uint32_t attr_count,
+                                    _Inout_ sai_attribute_t *attr_list)
+    {
+        if (attr_count == 1)
+        {
+            switch(attr_list[0].id)
+            {
+            case SAI_SWITCH_ATTR_MAX_ACL_ACTION_COUNT:
+                attr_list[0].value.u32 = 2;
+                return SAI_STATUS_SUCCESS;
+            case SAI_SWITCH_ATTR_ACL_STAGE_INGRESS:
+            case SAI_SWITCH_ATTR_ACL_STAGE_EGRESS:
+                attr_list[0].value.aclcapability.action_list.count = 2;
+                attr_list[0].value.aclcapability.action_list.list[0]= SAI_ACL_ACTION_TYPE_COUNTER;
+                attr_list[0].value.aclcapability.action_list.list[1]=
+                    attr_list[0].id == SAI_SWITCH_ATTR_ACL_STAGE_INGRESS ?
+                        SAI_ACL_ACTION_TYPE_MIRROR_INGRESS : SAI_ACL_ACTION_TYPE_MIRROR_EGRESS;
+                attr_list[0].value.aclcapability.is_action_list_mandatory = true;
+                return SAI_STATUS_SUCCESS;
+            }
+        }
+        return old_sai_switch_api->get_switch_attribute(switch_id, attr_count, attr_list);
+    }
+
+    TEST_F(AclOrchTest, AclTableCreationWithMandatoryActions)
+    {
+        // Override SAI API get_switch_attribute to request passing mandatory ACL actions to SAI
+        // when creating mirror ACL table.
+        old_sai_switch_api = sai_switch_api;
+        sai_switch_api_t new_sai_switch_api = *sai_switch_api;
+        sai_switch_api = &new_sai_switch_api;
+        sai_switch_api->get_switch_attribute = getSwitchAttribute;
+
+        // Set platform env to enable support of MIRRORV6 ACL table.
+        bool unset_platform_env = false;
+        if (!getenv("platform"))
+        {
+            setenv("platform", VS_PLATFORM_SUBSTRING, 0);
+            unset_platform_env = true;
+        }
+
+        auto orch = createAclOrch();
+
+        for (const auto &acl_table_type : { TABLE_TYPE_MIRROR, TABLE_TYPE_MIRRORV6, TABLE_TYPE_MIRROR_DSCP })
+        {
+            for (const auto &acl_table_stage : { STAGE_INGRESS, STAGE_EGRESS })
+            {
+                // Create ACL table.
+                string acl_table_id = "mirror_acl_table";
+                auto kvfAclTable = deque<KeyOpFieldsValuesTuple>(
+                    { { acl_table_id,
+                        SET_COMMAND,
+                        { { ACL_TABLE_DESCRIPTION, acl_table_type },
+                          { ACL_TABLE_TYPE, acl_table_type },
+                          { ACL_TABLE_STAGE, acl_table_stage },
+                          { ACL_TABLE_PORTS, "1,2" } } } });
+                orch->doAclTableTask(kvfAclTable);
+                auto acl_table = orch->getAclTable(acl_table_id);
+                ASSERT_NE(acl_table, nullptr);
+
+                // Verify mandaotry ACL actions has been added.
+                auto acl_actions = acl_table->type.getActions();
+                ASSERT_NE(acl_actions.find(SAI_ACL_ACTION_TYPE_COUNTER), acl_actions.end());
+                sai_acl_action_type_t action = strcmp(acl_table_stage, STAGE_INGRESS) == 0 ?
+                    SAI_ACL_ACTION_TYPE_MIRROR_INGRESS : SAI_ACL_ACTION_TYPE_MIRROR_EGRESS;
+                ASSERT_NE(acl_actions.find(action), acl_actions.end());
+
+                // Delete ACL table.
+                kvfAclTable = deque<KeyOpFieldsValuesTuple>(
+                    { { acl_table_id,
+                        DEL_COMMAND,
+                        {} } });
+                orch->doAclTableTask(kvfAclTable);
+                acl_table = orch->getAclTable(acl_table_id);
+                ASSERT_EQ(acl_table, nullptr);
+            }
+        }
+
+        // Unset platform env.
+        if (unset_platform_env)
+        {
+            unsetenv("platform");
+        }
+
+        // Restore sai_switch_api.
+        sai_switch_api = old_sai_switch_api;
+    }
 } // namespace nsAclOrchTest

--- a/tests/mock_tests/aclorch_ut.cpp
+++ b/tests/mock_tests/aclorch_ut.cpp
@@ -426,7 +426,12 @@ namespace aclorch_test
             };
             gRouteOrch = new RouteOrch(m_app_db.get(), route_tables, gSwitchOrch, gNeighOrch, gIntfsOrch, gVrfOrch, gFgNhgOrch, gSrv6Orch);
 
-            PolicerOrch *policer_orch = new PolicerOrch(m_config_db.get(), "POLICER");
+            vector<TableConnector> policer_tables = {
+                TableConnector(m_config_db.get(), CFG_POLICER_TABLE_NAME),
+                TableConnector(m_config_db.get(), CFG_PORT_STORM_CONTROL_TABLE_NAME)
+            };
+            TableConnector stateDbStorm(m_state_db.get(), "BUM_STORM_CAPABILITY");
+            PolicerOrch *policer_orch = new PolicerOrch(policer_tables, gPortsOrch);
 
             TableConnector stateDbMirrorSession(m_state_db.get(), STATE_MIRROR_SESSION_TABLE_NAME);
             TableConnector confDbMirrorSession(m_config_db.get(), CFG_MIRROR_SESSION_TABLE_NAME);

--- a/tests/mock_tests/buffermgrdyn_ut.cpp
+++ b/tests/mock_tests/buffermgrdyn_ut.cpp
@@ -1,0 +1,902 @@
+#define private public // make Directory::m_values available to clean it.
+#include "directory.h"
+#undef private
+#define protected public
+#include "orch.h"
+#undef protected
+#include "ut_helper.h"
+#include "mock_orchagent_main.h"
+#include "mock_table.h"
+#define private public
+#include "buffermgrdyn.h"
+#undef private
+#include "warm_restart.h"
+
+extern string gMySwitchType;
+
+
+namespace buffermgrdyn_test
+{
+    using namespace std;
+
+    shared_ptr<swss::DBConnector> m_app_db = make_shared<swss::DBConnector>("APPL_DB", 0);
+    shared_ptr<swss::DBConnector> m_config_db = make_shared<swss::DBConnector>("CONFIG_DB", 0);
+    shared_ptr<swss::DBConnector> m_state_db = make_shared<swss::DBConnector>("STATE_DB", 0);
+
+    BufferMgrDynamic *m_dynamicBuffer;
+    SelectableTimer m_selectableTable(timespec({ .tv_sec = BUFFERMGR_TIMER_PERIOD, .tv_nsec = 0 }), 0);
+    Table portTable(m_config_db.get(), CFG_PORT_TABLE_NAME);
+    Table cableLengthTable(m_config_db.get(), CFG_PORT_CABLE_LEN_TABLE_NAME);
+    Table bufferPoolTable(m_config_db.get(), CFG_BUFFER_POOL_TABLE_NAME);
+    Table bufferProfileTable(m_config_db.get(), CFG_BUFFER_PROFILE_TABLE_NAME);
+    Table bufferPgTable(m_config_db.get(), CFG_BUFFER_PG_TABLE_NAME);
+    Table bufferQueueTable(m_config_db.get(), CFG_BUFFER_QUEUE_TABLE_NAME);
+    Table bufferIngProfileListTable(m_config_db.get(), CFG_BUFFER_PORT_INGRESS_PROFILE_LIST_NAME);
+    Table bufferEgrProfileListTable(m_config_db.get(), CFG_BUFFER_PORT_EGRESS_PROFILE_LIST_NAME);
+    Table defaultLosslessParameterTable(m_config_db.get(), CFG_DEFAULT_LOSSLESS_BUFFER_PARAMETER);
+    Table appPortTable(m_app_db.get(), APP_PORT_TABLE_NAME);
+    Table appBufferPoolTable(m_app_db.get(), APP_BUFFER_POOL_TABLE_NAME);
+    Table appBufferProfileTable(m_app_db.get(), APP_BUFFER_PROFILE_TABLE_NAME);
+    Table appBufferPgTable(m_app_db.get(), APP_BUFFER_PG_TABLE_NAME);
+    Table appBufferQueueTable(m_app_db.get(), APP_BUFFER_QUEUE_TABLE_NAME);
+    Table appBufferIngProfileListTable(m_app_db.get(), APP_BUFFER_PORT_INGRESS_PROFILE_LIST_NAME);
+    Table appBufferEgrProfileListTable(m_app_db.get(), APP_BUFFER_PORT_EGRESS_PROFILE_LIST_NAME);
+    Table bufferMaxParamTable(m_state_db.get(), STATE_BUFFER_MAXIMUM_VALUE_TABLE);
+    Table statePortTable(m_state_db.get(), STATE_PORT_TABLE_NAME);
+    Table stateBufferTable(m_state_db.get(), STATE_BUFFER_MAXIMUM_VALUE_TABLE);
+
+    map<string, vector<FieldValueTuple>> zeroProfileMap;
+    vector<KeyOpFieldsValuesTuple> zeroProfile;
+
+    struct BufferMgrDynTest : public ::testing::Test
+    {
+        map<string, vector<FieldValueTuple>> testBufferProfile;
+        map<string, vector<FieldValueTuple>> testBufferPool;
+
+        void SetUpReclaimingBuffer()
+        {
+            zeroProfileMap["ingress_zero_pool"] = {
+                {"mode", "static"},
+                {"type", "ingress"},
+                {"size", "0"}
+            };
+            zeroProfileMap["ingress_lossy_pg_zero_profile"] = {
+                {"pool", "ingress_zero_pool"},
+                {"size", "0"},
+                {"static_th", "0"}
+            };
+            zeroProfileMap["ingress_lossless_zero_profile"] = {
+                {"pool", "ingress_lossless_pool"},
+                {"size", "0"},
+                {"dynamic_th", "-8"}
+            };
+            zeroProfileMap["egress_lossy_zero_profile"] = {
+                {"pool", "egress_lossy_pool"},
+                {"size", "0"},
+                {"dynamic_th", "-8"}
+            };
+            zeroProfileMap["egress_lossless_zero_profile"] = {
+                {"pool", "egress_lossless_pool"},
+                {"size", "0"},
+                {"dynamic_th", "-8"}
+            };
+
+            zeroProfile = {
+                {
+                    "BUFFER_POOL_TABLE:ingress_zero_pool",
+                    "SET",
+                    zeroProfileMap["ingress_zero_pool"]
+                },
+                {
+                    "BUFFER_PROFILE_TABLE:ingress_lossy_pg_zero_profile",
+                    "SET",
+                    zeroProfileMap["ingress_lossy_pg_zero_profile"]
+                },
+                {
+                    "BUFFER_PROFILE_TABLE:ingress_lossless_zero_profile",
+                    "SET",
+                    zeroProfileMap["ingress_lossless_zero_profile"]
+                },
+                {
+                    "BUFFER_PROFILE_TABLE:egress_lossy_zero_profile",
+                    "SET",
+                    zeroProfileMap["egress_lossy_zero_profile"]
+                },
+                {
+                    "BUFFER_PROFILE_TABLE:egress_lossless_zero_profile",
+                    "SET",
+                    zeroProfileMap["egress_lossless_zero_profile"]
+                },
+                {
+                    "control_fields",
+                    "SET",
+                    {
+                        {"pgs_to_apply_zero_profile", "0"},
+                        {"ingress_zero_profile", "ingress_lossy_pg_zero_profile"}
+                    }
+                }
+            };
+        }
+
+        BufferMgrDynTest()
+        {
+            testBufferPool["ingress_lossless_pool"] = {
+                {"mode", "dynamic"},
+                {"type", "ingress"},
+                {"size", "1024000"}
+            };
+            testBufferPool["egress_lossless_pool"] = {
+                {"mode", "dynamic"},
+                {"type", "egress"},
+                {"size", "1024000"}
+            };
+            testBufferPool["egress_lossy_pool"] = {
+                {"mode", "dynamic"},
+                {"type", "egress"},
+                {"size", "1024000"}
+            };
+
+            testBufferProfile["ingress_lossless_profile"] = {
+                {"dynamic_th", "7"},
+                {"pool", "ingress_lossless_pool"},
+                {"size", "0"}
+            };
+            testBufferProfile["egress_lossless_profile"] = {
+                {"dynamic_th", "7"},
+                {"pool", "egress_lossless_pool"},
+                {"size", "0"}
+            };
+            testBufferProfile["egress_lossy_profile"] = {
+                {"dynamic_th", "3"},
+                {"pool", "egress_lossy_pool"},
+                {"size", "0"}
+            };
+        }
+
+        void SetUp() override
+        {
+            setenv("ASIC_VENDOR", "mock_test", 1);
+
+            testing_db::reset();
+
+            WarmStart::initialize("buffermgrd", "swss");
+            WarmStart::checkWarmStart("buffermgrd", "swss");
+        }
+
+        void StartBufferManager(shared_ptr<vector<KeyOpFieldsValuesTuple>> zero_profile=nullptr)
+        {
+            // Init switch and create dependencies
+            vector<TableConnector> buffer_table_connectors = {
+                TableConnector(m_config_db.get(), CFG_PORT_TABLE_NAME),
+                TableConnector(m_config_db.get(), CFG_PORT_CABLE_LEN_TABLE_NAME),
+                TableConnector(m_config_db.get(), CFG_BUFFER_POOL_TABLE_NAME),
+                TableConnector(m_config_db.get(), CFG_BUFFER_PROFILE_TABLE_NAME),
+                TableConnector(m_config_db.get(), CFG_BUFFER_PG_TABLE_NAME),
+                TableConnector(m_config_db.get(), CFG_BUFFER_QUEUE_TABLE_NAME),
+                TableConnector(m_config_db.get(), CFG_BUFFER_PORT_INGRESS_PROFILE_LIST_NAME),
+                TableConnector(m_config_db.get(), CFG_BUFFER_PORT_EGRESS_PROFILE_LIST_NAME),
+                TableConnector(m_config_db.get(), CFG_DEFAULT_LOSSLESS_BUFFER_PARAMETER),
+                TableConnector(m_state_db.get(), STATE_BUFFER_MAXIMUM_VALUE_TABLE),
+                TableConnector(m_state_db.get(), STATE_PORT_TABLE_NAME)
+            };
+
+            m_dynamicBuffer = new BufferMgrDynamic(m_config_db.get(), m_state_db.get(), m_app_db.get(), buffer_table_connectors, nullptr, zero_profile);
+        }
+
+        void InitPort(const string &port="Ethernet0", const string &admin_status="up")
+        {
+            portTable.set(port,
+                          {
+                              {"speed", "100000"},
+                              {"mtu", "9100"},
+                              {"admin_status", admin_status}
+                          });
+            m_dynamicBuffer->addExistingData(&portTable);
+            static_cast<Orch *>(m_dynamicBuffer)->doTask();
+        }
+
+        void SetPortInitDone()
+        {
+            appPortTable.set("PortInitDone",
+                             {
+                                 {"lanes", "0"}
+                             });
+            m_dynamicBuffer->addExistingData(&appPortTable);
+            static_cast<Orch *>(m_dynamicBuffer)->doTask();
+        }
+
+        void InitMmuSize()
+        {
+            bufferMaxParamTable.set("global",
+                                    {
+                                        {"mmu_size", "1024000"}
+                                    });
+            if (m_dynamicBuffer)
+                m_dynamicBuffer->addExistingData(&bufferMaxParamTable);
+        }
+
+        void InitDefaultLosslessParameter(const string &over_subscribe_ratio="")
+        {
+            if (over_subscribe_ratio.empty())
+            {
+                defaultLosslessParameterTable.set("AZURE",
+                                                  {
+                                                      {"default_dynamic_th", "0"}
+                                                  });
+            }
+            else
+            {
+                defaultLosslessParameterTable.set("AZURE",
+                                                  {
+                                                      {"default_dynamic_th", "0"},
+                                                      {"over_subscribe_ratio", over_subscribe_ratio}
+                                                  });
+            }
+            if (m_dynamicBuffer)
+            {
+                m_dynamicBuffer->addExistingData(&defaultLosslessParameterTable);
+                static_cast<Orch *>(m_dynamicBuffer)->doTask();
+            }
+        }
+
+        void InitBufferPool()
+        {
+            for(auto &i: testBufferPool)
+            {
+                bufferPoolTable.set(i.first, i.second);
+            }
+
+            m_dynamicBuffer->addExistingData(&bufferPoolTable);
+            static_cast<Orch *>(m_dynamicBuffer)->doTask();
+        }
+
+        void ClearBufferPool(const string &skippedPool="", const string &clearPool="")
+        {
+            std::deque<KeyOpFieldsValuesTuple> entries;
+            for (auto &i: testBufferPool)
+            {
+                if (skippedPool == i.first)
+                    continue;
+                if (!clearPool.empty() && clearPool != i.first)
+                    continue;
+                entries.push_back({i.first, "DEL", {}});
+            }
+
+            auto consumer = dynamic_cast<Consumer *>(m_dynamicBuffer->getExecutor(CFG_BUFFER_POOL_TABLE_NAME));
+            consumer->addToSync(entries);
+            static_cast<Orch *>(m_dynamicBuffer)->doTask();
+        }
+
+        void InitDefaultBufferProfile()
+        {
+            for (auto &i: testBufferProfile)
+            {
+                bufferProfileTable.set(i.first, i.second);
+            }
+
+            m_dynamicBuffer->addExistingData(&bufferProfileTable);
+            static_cast<Orch *>(m_dynamicBuffer)->doTask();
+        }
+
+        void ClearBufferProfile()
+        {
+            std::deque<KeyOpFieldsValuesTuple> entries;
+            for (auto &i: testBufferProfile)
+                entries.push_back({i.first, "DEL", {}});
+
+            auto consumer = dynamic_cast<Consumer *>(m_dynamicBuffer->getExecutor(CFG_BUFFER_PROFILE_TABLE_NAME));
+            consumer->addToSync(entries);
+            static_cast<Orch *>(m_dynamicBuffer)->doTask();
+        }
+
+        void InitBufferPg(const string &key, const string &profile="NULL")
+        {
+            bufferPgTable.set(key,
+                              {
+                                  {"profile", profile}
+                              });
+            m_dynamicBuffer->addExistingData(&bufferPgTable);
+            static_cast<Orch *>(m_dynamicBuffer)->doTask();
+        }
+
+        void ClearBufferObject(const string &key, const string &tableName)
+        {
+            std::deque<KeyOpFieldsValuesTuple> entries;
+            entries.push_back({key, "DEL", {}});
+
+            auto consumer = dynamic_cast<Consumer *>(m_dynamicBuffer->getExecutor(tableName));
+            consumer->addToSync(entries);
+            static_cast<Orch *>(m_dynamicBuffer)->doTask();
+
+            Table tableObject(m_config_db.get(), tableName);
+            tableObject.del(key);
+        }
+
+        void InitBufferQueue(const string &key, const string &profile)
+        {
+            bufferQueueTable.set(key,
+                                 {
+                                     {"profile", profile}
+                                 });
+            m_dynamicBuffer->addExistingData(&bufferQueueTable);
+            static_cast<Orch *>(m_dynamicBuffer)->doTask();
+        }
+
+        void InitBufferProfileList(const string &ports, const string &profileList, Table &appDb)
+        {
+            appDb.set(ports,
+                      {
+                          {"profile_list", profileList}
+                      });
+            m_dynamicBuffer->addExistingData(&appDb);
+            static_cast<Orch *>(m_dynamicBuffer)->doTask();
+        }
+
+        void InitCableLength(const string &port, const string &length)
+        {
+            cableLengthTable.set("AZURE",
+                                 {
+                                     {port, length}
+                                 });
+            m_dynamicBuffer->addExistingData(&cableLengthTable);
+            static_cast<Orch *>(m_dynamicBuffer)->doTask();
+        }
+
+        void HandleTable(Table &table)
+        {
+            m_dynamicBuffer->addExistingData(&table);
+            static_cast<Orch *>(m_dynamicBuffer)->doTask();
+        }
+
+        void CheckPool(buffer_pool_t &pool, const vector<FieldValueTuple> &tuples)
+        {
+            for (auto i : tuples)
+            {
+                if (fvField(i) == buffer_pool_type_field_name)
+                {
+                    if (fvValue(i) == buffer_value_ingress)
+                        ASSERT_EQ(pool.direction, BUFFER_INGRESS);
+                    else
+                        ASSERT_EQ(pool.direction, BUFFER_EGRESS);
+                }
+                else if (fvField(i) == buffer_pool_mode_field_name)
+                {
+                    ASSERT_EQ(pool.mode, fvValue(i));
+                }
+                else if (fvField(i) == buffer_size_field_name)
+                {
+                    ASSERT_TRUE(!pool.dynamic_size);
+                    ASSERT_EQ("1024000", fvValue(i));
+                }
+            }
+        }
+
+        void CheckProfile(buffer_profile_t &profile, const vector<FieldValueTuple> &tuples)
+        {
+            for (auto i : tuples)
+            {
+                if (fvField(i) == buffer_pool_field_name)
+                {
+                    ASSERT_EQ(profile.pool_name, fvValue(i));
+                    if (strstr(profile.pool_name.c_str(), "ingress") != nullptr)
+                        ASSERT_EQ(profile.direction, BUFFER_INGRESS);
+                    else
+                        ASSERT_EQ(profile.direction, BUFFER_EGRESS);
+                }
+                else if (fvField(i) == buffer_dynamic_th_field_name)
+                {
+                    ASSERT_EQ(profile.threshold_mode, buffer_dynamic_th_field_name);
+                    ASSERT_EQ(profile.threshold, fvValue(i));
+                }
+                else if (fvField(i) == buffer_size_field_name)
+                {
+                    ASSERT_EQ(profile.size, fvValue(i));
+                }
+            }
+        }
+
+        void CheckPg(const string &port, const string &key, const string &expectedProfile="")
+        {
+            vector<FieldValueTuple> fieldValues;
+
+            ASSERT_TRUE(m_dynamicBuffer->m_portPgLookup[port][key].dynamic_calculated);
+            ASSERT_TRUE(m_dynamicBuffer->m_portPgLookup[port][key].lossless);
+
+            auto existInDb = (!expectedProfile.empty());
+            ASSERT_EQ(appBufferPgTable.get(key, fieldValues), existInDb);
+            if (existInDb)
+            {
+                ASSERT_EQ(m_dynamicBuffer->m_portPgLookup[port][key].running_profile_name, expectedProfile);
+                ASSERT_EQ(fvField(fieldValues[0]), "profile");
+                ASSERT_EQ(fvValue(fieldValues[0]), expectedProfile);
+            }
+        }
+
+        void CheckQueue(const string &port, const string &key, const string &expectedProfile, bool existInDb)
+        {
+            vector<FieldValueTuple> fieldValues;
+
+            ASSERT_EQ(m_dynamicBuffer->m_portQueueLookup[port][key].running_profile_name, expectedProfile);
+            ASSERT_EQ(appBufferQueueTable.get(key, fieldValues), existInDb);
+            if (existInDb)
+            {
+                ASSERT_EQ(fvField(fieldValues[0]), "profile");
+                ASSERT_EQ(fvValue(fieldValues[0]), expectedProfile);
+            }
+        }
+
+        void CheckProfileList(const string &port, bool ingress, const string &profileList, bool existInDb=true)
+        {
+            vector<FieldValueTuple> fieldValues;
+
+            auto direction = ingress ? BUFFER_INGRESS : BUFFER_EGRESS;
+            ASSERT_EQ(m_dynamicBuffer->m_portProfileListLookups[direction][port], profileList);
+
+            auto &appDb = ingress ? appBufferIngProfileListTable : appBufferEgrProfileListTable;
+
+            ASSERT_EQ(appDb.get(port, fieldValues), existInDb);
+            if (existInDb)
+            {
+                ASSERT_EQ(fieldValues.size(), 1);
+                ASSERT_EQ(fvField(fieldValues[0]), "profile_list");
+                ASSERT_EQ(fvValue(fieldValues[0]), profileList);
+            }
+        }
+
+        void CheckIfVectorsMatch(const vector<FieldValueTuple> &vec1, const vector<FieldValueTuple> &vec2)
+        {
+            ASSERT_EQ(vec1.size(), vec2.size());
+            for (auto &i : vec1)
+            {
+                bool found = false;
+                for (auto &j : vec2)
+                {
+                    if (i == j)
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+                ASSERT_TRUE(found);
+            }
+        }
+
+        void TearDown() override
+        {
+            delete m_dynamicBuffer;
+            m_dynamicBuffer = nullptr;
+
+            unsetenv("ASIC_VENDOR");
+        }
+    };
+
+    /*
+     * Dependencies
+     * 1. Buffer manager reads default lossless parameter and maximum mmu size at the beginning
+     * 2. Maximum mmu size will be pushed ahead of PortInitDone
+     * 3. Buffer pools can be ready at any time after PortInitDone
+     * 4. Buffer tables can be applied in any order
+     * 5. Port and buffer PG can be applied in any order
+     * 6. Sequence after config qos clear
+     */
+
+    /*
+     * Normal starting flow
+     * 1. Start buffer manager with default lossless parameter and maximum mmu size
+     * 2. PortInitDone
+     * 3. Cable length and port configuration
+     * 4. Buffer tables: BUFFER_POOL/BUFFER_PROFILE/BUFFER_PG
+     * 5. Queue and buffer profile lists with/without port created
+     */
+    TEST_F(BufferMgrDynTest, BufferMgrTestNormalFlows)
+    {
+        vector<FieldValueTuple> fieldValues;
+        vector<string> keys;
+
+        // Prepare information that will be read at the beginning
+        InitDefaultLosslessParameter();
+        InitMmuSize();
+
+        StartBufferManager();
+
+        InitPort();
+        ASSERT_EQ(m_dynamicBuffer->m_portInfoLookup["Ethernet0"].state, PORT_INITIALIZING);
+
+        SetPortInitDone();
+        // Timer will be called
+        m_dynamicBuffer->doTask(m_selectableTable);
+
+        ASSERT_EQ(m_dynamicBuffer->m_bufferPoolLookup.size(), 0);
+        InitBufferPool();
+        ASSERT_EQ(m_dynamicBuffer->m_bufferPoolLookup.size(), 3);
+        appBufferPoolTable.getKeys(keys);
+        ASSERT_EQ(keys.size(), 3);
+        for (auto i : testBufferPool)
+        {
+            CheckPool(m_dynamicBuffer->m_bufferPoolLookup[i.first], testBufferPool[i.first]);
+            fieldValues.clear();
+            appBufferPoolTable.get(i.first, fieldValues);
+            CheckPool(m_dynamicBuffer->m_bufferPoolLookup[i.first], fieldValues);
+        }
+
+        InitDefaultBufferProfile();
+        appBufferProfileTable.getKeys(keys);
+        ASSERT_EQ(keys.size(), 3);
+        ASSERT_EQ(m_dynamicBuffer->m_bufferProfileLookup.size(), 3);
+        for (auto i : testBufferProfile)
+        {
+            CheckProfile(m_dynamicBuffer->m_bufferProfileLookup[i.first], testBufferProfile[i.first]);
+            fieldValues.clear();
+            appBufferProfileTable.get(i.first, fieldValues);
+            CheckProfile(m_dynamicBuffer->m_bufferProfileLookup[i.first], fieldValues);
+        }
+
+        InitCableLength("Ethernet0", "5m");
+        ASSERT_EQ(m_dynamicBuffer->m_portInfoLookup["Ethernet0"].state, PORT_READY);
+
+        InitBufferPg("Ethernet0|3-4");
+
+        auto expectedProfile = "pg_lossless_100000_5m_profile";
+        CheckPg("Ethernet0", "Ethernet0:3-4", expectedProfile);
+        auto &portPgMap = m_dynamicBuffer->m_bufferProfileLookup[expectedProfile].port_pgs;
+        ASSERT_EQ(portPgMap.size(), 1);
+        ASSERT_TRUE(portPgMap.find("Ethernet0:3-4") != portPgMap.end());
+
+        // Multiple port key
+        InitBufferPg("Ethernet2,Ethernet4|3-4");
+
+        CheckPg("Ethernet2", "Ethernet2:3-4");
+        CheckPg("Ethernet4", "Ethernet4:3-4");
+
+        // Buffer queue, ingress and egress profile list table
+        InitPort("Ethernet2");
+        InitPort("Ethernet4");
+
+        InitBufferQueue("Ethernet2,Ethernet4,Ethernet6|3-4", "egress_lossless_profile");
+        CheckQueue("Ethernet2", "Ethernet2:3-4", "egress_lossless_profile", true);
+        CheckQueue("Ethernet4", "Ethernet4:3-4", "egress_lossless_profile", true);
+
+        InitBufferProfileList("Ethernet2,Ethernet4,Ethernet6", "ingress_lossless_profile", bufferIngProfileListTable);
+        CheckProfileList("Ethernet2", true, "ingress_lossless_profile");
+        CheckProfileList("Ethernet4", true, "ingress_lossless_profile");
+
+        InitBufferProfileList("Ethernet2,Ethernet4,Ethernet6", "egress_lossless_profile,egress_lossy_profile", bufferEgrProfileListTable);
+        CheckProfileList("Ethernet2", false, "egress_lossless_profile,egress_lossy_profile");
+        CheckProfileList("Ethernet4", false, "egress_lossless_profile,egress_lossy_profile");
+
+        // Check whether queue, profile lists have been applied after port created
+        InitPort("Ethernet6");
+        CheckQueue("Ethernet6", "Ethernet6:3-4", "egress_lossless_profile", true);
+        CheckProfileList("Ethernet6", true, "ingress_lossless_profile");
+        CheckProfileList("Ethernet6", false, "egress_lossless_profile,egress_lossy_profile");
+    }
+
+    /*
+     * Verify a buffer pool will not be created without corresponding item in BUFFER_POOL
+     * otherwise it interferes starting flow
+     * 1. Configure oversubscribe ratio
+     * 2. Check whether ingress_lossless_pool is created
+     */
+    TEST_F(BufferMgrDynTest, BufferMgrTestNoPoolCreatedWithoutDb)
+    {
+        StartBufferManager();
+
+        InitMmuSize();
+        InitDefaultLosslessParameter("0");
+        InitPort("Ethernet0");
+
+        static_cast<Orch *>(m_dynamicBuffer)->doTask();
+        m_dynamicBuffer->doTask(m_selectableTable);
+
+        ASSERT_TRUE(m_dynamicBuffer->m_bufferPoolLookup.empty());
+
+        InitBufferPool();
+        static_cast<Orch *>(m_dynamicBuffer)->doTask();
+
+        ASSERT_FALSE(m_dynamicBuffer->m_bufferPoolLookup.empty());
+    }
+
+    /*
+     * Sad flows test. Order is reversed in the following cases:
+     * - The buffer table creating. The tables referencing other tables are created first
+     * - Buffer manager starts with neither default lossless parameter nor maximum mmu size available
+     *
+     * 1. Start buffer manager without default lossless parameter and maximum mmu size
+     * 2. Buffer tables are applied in order:
+     *    - Port configuration
+     *    - BUFFER_QUEUE/buffer profile list
+     *    - BUFFER_PG/BUFFER_PROFILE/BUFFER_POOL
+     *    - PortInitDone
+     * 3. Cable length
+     * 4. Create a buffer profile with wrong threshold mode or direction
+     *    and verify it will not be propagated to SAI
+     */
+    TEST_F(BufferMgrDynTest, BufferMgrTestSadFlows)
+    {
+        vector<string> ts;
+        vector<FieldValueTuple> fieldValues;
+        vector<string> keys;
+
+        StartBufferManager();
+
+        static_cast<Orch *>(m_dynamicBuffer)->doTask();
+
+        InitPort();
+
+        InitBufferPg("Ethernet0|3-4");
+        // No item generated in BUFFER_PG_TABLE
+        CheckPg("Ethernet0", "Ethernet0:3-4");
+
+        InitBufferQueue("Ethernet0|3-4", "egress_lossless_profile");
+        ASSERT_TRUE(m_dynamicBuffer->m_portQueueLookup["Ethernet0"]["Ethernet0:3-4"].running_profile_name.empty());
+
+        InitBufferProfileList("Ethernet0", "ingress_lossless_profile", bufferIngProfileListTable);
+        ASSERT_TRUE(m_dynamicBuffer->m_portProfileListLookups[BUFFER_INGRESS]["Ethernet0"].empty());
+
+        InitBufferProfileList("Ethernet0", "egress_lossless_profile,egress_lossy_profile", bufferEgrProfileListTable);
+        ASSERT_TRUE(m_dynamicBuffer->m_portProfileListLookups[BUFFER_EGRESS]["Ethernet0"].empty());
+
+        InitDefaultBufferProfile();
+        appBufferProfileTable.getKeys(keys);
+        ASSERT_EQ(keys.size(), 0);
+        ASSERT_EQ(m_dynamicBuffer->m_bufferProfileLookup.size(), 0);
+
+        ASSERT_EQ(m_dynamicBuffer->m_bufferPoolLookup.size(), 0);
+        InitBufferPool();
+        appBufferPoolTable.getKeys(keys);
+        ASSERT_EQ(keys.size(), 3);
+        ASSERT_EQ(m_dynamicBuffer->m_bufferPoolLookup.size(), 3);
+        ASSERT_EQ(m_dynamicBuffer->m_bufferProfileLookup.size(), 3);
+        for (auto i : testBufferProfile)
+        {
+            CheckProfile(m_dynamicBuffer->m_bufferProfileLookup[i.first], testBufferProfile[i.first]);
+            fieldValues.clear();
+            appBufferProfileTable.get(i.first, fieldValues);
+            CheckProfile(m_dynamicBuffer->m_bufferProfileLookup[i.first], fieldValues);
+        }
+        for (auto i : testBufferPool)
+        {
+            CheckPool(m_dynamicBuffer->m_bufferPoolLookup[i.first], testBufferPool[i.first]);
+            fieldValues.clear();
+            appBufferPoolTable.get(i.first, fieldValues);
+            CheckPool(m_dynamicBuffer->m_bufferPoolLookup[i.first], fieldValues);
+        }
+
+        ASSERT_EQ(m_dynamicBuffer->m_portPgLookup.size(), 1);
+        static_cast<Orch *>(m_dynamicBuffer)->doTask();
+        CheckProfileList("Ethernet0", true, "ingress_lossless_profile", false);
+        CheckProfileList("Ethernet0", false, "egress_lossless_profile,egress_lossy_profile", false);
+
+        // All default buffer profiles should be generated and pushed into BUFFER_PROFILE_TABLE
+        static_cast<Orch *>(m_dynamicBuffer)->doTask();
+
+        InitMmuSize();
+        SetPortInitDone();
+        m_dynamicBuffer->doTask(m_selectableTable);
+
+        InitDefaultLosslessParameter();
+        m_dynamicBuffer->doTask(m_selectableTable);
+
+        CheckPg("Ethernet0", "Ethernet0:3-4");
+        InitCableLength("Ethernet0", "5m");
+        auto expectedProfile = "pg_lossless_100000_5m_profile";
+        CheckPg("Ethernet0", "Ethernet0:3-4", expectedProfile);
+        CheckQueue("Ethernet0", "Ethernet0:3-4", "egress_lossless_profile", true);
+
+        CheckProfileList("Ethernet0", true, "ingress_lossless_profile", true);
+        CheckProfileList("Ethernet0", false, "egress_lossless_profile,egress_lossy_profile", true);
+
+        InitPort("Ethernet4");
+        InitPort("Ethernet6");
+        InitBufferQueue("Ethernet6|0-2", "egress_lossy_profile");
+        InitBufferProfileList("Ethernet6", "ingress_lossless_profile", bufferIngProfileListTable);
+
+        // Buffer queue/PG/profile lists with wrong direction should not overwrite the existing ones
+        vector<string> ingressProfiles = {"egress_lossy_profile", "ingress_profile", ""};
+        vector<string> portsToTest = {"Ethernet0", "Ethernet4"};
+        for (auto port : portsToTest)
+        {
+            for (auto ingressProfile : ingressProfiles)
+            {
+                InitBufferPg(port + "|3-4", ingressProfile);
+                if (port == "Ethernet0")
+                {
+                    ASSERT_EQ(m_dynamicBuffer->m_portPgLookup["Ethernet0"]["Ethernet0:3-4"].running_profile_name, expectedProfile);
+                    ASSERT_TRUE(appBufferPgTable.get("Ethernet0:3-4", fieldValues));
+                    CheckIfVectorsMatch(fieldValues, {{"profile", expectedProfile}});
+                }
+                else
+                {
+                    ASSERT_TRUE(m_dynamicBuffer->m_portPgLookup[port].find(port + ":3-4") == m_dynamicBuffer->m_portPgLookup[port].end());
+                    ASSERT_FALSE(appBufferPgTable.get(port + ":3-4", fieldValues));
+                }
+            }
+        }
+
+        InitBufferQueue("Ethernet4|0-2", "ingress_lossless_profile");
+        ASSERT_TRUE(m_dynamicBuffer->m_portQueueLookup["Ethernet4"]["Ethernet0:0-2"].running_profile_name.empty());
+        ASSERT_FALSE(appBufferQueueTable.get("Ethernet4:0-2", fieldValues));
+        // No pending notifications
+        ts.clear();
+        m_dynamicBuffer->dumpPendingTasks(ts);
+        ASSERT_EQ(ts.size(), 0);
+
+        InitBufferQueue("Ethernet6|0-2", "ingress_lossless_profile");
+        ASSERT_EQ(m_dynamicBuffer->m_portQueueLookup["Ethernet6"]["Ethernet6:0-2"].running_profile_name, "egress_lossy_profile");
+        ASSERT_TRUE(appBufferQueueTable.get("Ethernet6:0-2", fieldValues));
+        CheckIfVectorsMatch(fieldValues, {{"profile", "egress_lossy_profile"}});
+        // No pending notifications
+        m_dynamicBuffer->dumpPendingTasks(ts);
+        ASSERT_EQ(ts.size(), 0);
+
+        // Wrong direction
+        InitBufferProfileList("Ethernet4", "egress_lossless_profile", bufferIngProfileListTable);
+        ASSERT_TRUE(m_dynamicBuffer->m_portProfileListLookups[BUFFER_INGRESS]["Ethernet4"].empty());
+        ASSERT_FALSE(appBufferIngProfileListTable.get("Ethernet4", fieldValues));
+        // No pending notifications
+        m_dynamicBuffer->dumpPendingTasks(ts);
+        ASSERT_EQ(ts.size(), 0);
+
+        InitBufferProfileList("Ethernet6", "egress_lossless_profile", bufferIngProfileListTable);
+        ASSERT_EQ(m_dynamicBuffer->m_portProfileListLookups[BUFFER_INGRESS]["Ethernet6"], "ingress_lossless_profile");
+        ASSERT_TRUE(appBufferIngProfileListTable.get("Ethernet6", fieldValues));
+        CheckIfVectorsMatch(fieldValues, {{"profile_list", "ingress_lossless_profile"}});
+        // No pending notifications
+        m_dynamicBuffer->dumpPendingTasks(ts);
+        ASSERT_EQ(ts.size(), 0);
+
+        // Profile with wrong mode should not override the existing entries
+        vector<string> wrong_profile_names = {"ingress_lossless_profile", "wrong_param_profile"};
+        vector<vector<FieldValueTuple>> wrong_profile_patterns = {
+            // wrong threshold mode
+            {
+                {"pool", "ingress_lossless_pool"},
+                {"static_th", "100"},
+                {"size", "0"}
+            },
+            // unconfigured pool
+            {
+                {"pool", "ingress_pool"},
+                {"dynamic_th", "0"},
+                {"size", "0"}
+            }
+        };
+        auto expected_pending_tasks = 0;
+        for (auto wrong_profile_name : wrong_profile_names)
+        {
+            bool exist = (testBufferProfile.find(wrong_profile_name) != testBufferProfile.end());
+            for (auto wrong_profile_pattern : wrong_profile_patterns)
+            {
+                bufferProfileTable.set(wrong_profile_name, wrong_profile_pattern);
+                m_dynamicBuffer->addExistingData(&bufferProfileTable);
+                static_cast<Orch *>(m_dynamicBuffer)->doTask();
+                if (exist)
+                    CheckProfile(m_dynamicBuffer->m_bufferProfileLookup[wrong_profile_name], testBufferProfile[wrong_profile_name]);
+                else
+                    ASSERT_EQ(m_dynamicBuffer->m_bufferProfileLookup.find(wrong_profile_name), m_dynamicBuffer->m_bufferProfileLookup.end());
+                ASSERT_EQ(appBufferProfileTable.get(wrong_profile_name, fieldValues), exist);
+                // No pending notifications
+                ts.clear();
+                m_dynamicBuffer->dumpPendingTasks(ts);
+                if (get<1>(wrong_profile_pattern[0]) == "ingress_pool")
+                    expected_pending_tasks++;
+                ASSERT_EQ(ts.size(), expected_pending_tasks);
+            }
+        }
+    }
+
+    /*
+     * Port configuration flow
+     * Port table items are received in different order
+     */
+    TEST_F(BufferMgrDynTest, BufferMgrTestPortConfigFlow)
+    {
+        // Prepare information that will be read at the beginning
+        StartBufferManager();
+
+        /*
+         * Speed, admin up, cable length
+         */
+        portTable.set("Ethernet0",
+                      {
+                          {"speed", "100000"}
+                      });
+        HandleTable(portTable);
+        ASSERT_TRUE(m_dynamicBuffer->m_portInfoLookup.find("Ethernet0") != m_dynamicBuffer->m_portInfoLookup.end());
+        ASSERT_EQ(m_dynamicBuffer->m_portInfoLookup["Ethernet0"].state, PORT_ADMIN_DOWN);
+
+        portTable.set("Ethernet0",
+                      {
+                          {"speed", "100000"},
+                          {"admin_status", "up"}
+                      });
+        HandleTable(portTable);
+        ASSERT_EQ(m_dynamicBuffer->m_portInfoLookup["Ethernet0"].state, PORT_INITIALIZING);
+
+        cableLengthTable.set("AZURE",
+                             {
+                                 {"Ethernet0", "5m"}
+                             });
+        HandleTable(cableLengthTable);
+        ASSERT_EQ(m_dynamicBuffer->m_portInfoLookup["Ethernet0"].state, PORT_READY);
+
+        /*
+         * Speed, admin down, cable length, admin up
+         */
+        portTable.set("Ethernet4",
+                      {
+                          {"speed", "100000"},
+                          {"admin_status", "down"}
+                      });
+        HandleTable(portTable);
+        ASSERT_EQ(m_dynamicBuffer->m_portInfoLookup["Ethernet4"].state, PORT_ADMIN_DOWN);
+        cableLengthTable.set("AZURE",
+                             {
+                                 {"Ethernet4", "5m"}
+                             });
+        HandleTable(cableLengthTable);
+        ASSERT_EQ(m_dynamicBuffer->m_portInfoLookup["Ethernet4"].state, PORT_ADMIN_DOWN);
+        portTable.set("Ethernet4",
+                      {
+                          {"speed", "100000"},
+                          {"admin_status", "up"}
+                      });
+        HandleTable(portTable);
+        ASSERT_EQ(m_dynamicBuffer->m_portInfoLookup["Ethernet4"].state, PORT_READY);
+
+        /*
+         * Auto-negotiation: supported speeds received after port table
+         */
+        portTable.set("Ethernet8",
+                      {
+                          {"speed", "100000"},
+                          {"admin_status", "up"},
+                          {"autoneg", "on"}
+                      });
+        HandleTable(portTable);
+        ASSERT_EQ(m_dynamicBuffer->m_portInfoLookup["Ethernet8"].state, PORT_INITIALIZING);
+        ASSERT_TRUE(m_dynamicBuffer->m_portInfoLookup["Ethernet8"].effective_speed.empty());
+
+        cableLengthTable.set("AZURE",
+                             {
+                                 {"Ethernet8", "5m"}
+                             });
+        HandleTable(cableLengthTable);
+        ASSERT_EQ(m_dynamicBuffer->m_portInfoLookup["Ethernet8"].state, PORT_INITIALIZING);
+
+        statePortTable.set("Ethernet8",
+                           {
+                               {"supported_speeds", "100000,50000,40000,25000,10000,1000"}
+                           });
+        HandleTable(statePortTable);
+        ASSERT_EQ(m_dynamicBuffer->m_portInfoLookup["Ethernet8"].effective_speed, "100000");
+        ASSERT_EQ(m_dynamicBuffer->m_portInfoLookup["Ethernet8"].state, PORT_READY);
+
+        /*
+         * Auto-negotiation: supported speeds received before port table
+         */
+        statePortTable.set("Ethernet12",
+                           {
+                               {"supported_speeds", "100000,50000,40000,25000,10000,1000"}
+                           });
+        HandleTable(statePortTable);
+        ASSERT_EQ(m_dynamicBuffer->m_portInfoLookup["Ethernet12"].supported_speeds, "100000,50000,40000,25000,10000,1000");
+
+        portTable.set("Ethernet12",
+                      {
+                          {"speed", "100000"},
+                          {"admin_status", "up"},
+                          {"autoneg", "on"}
+                      });
+        HandleTable(portTable);
+        ASSERT_EQ(m_dynamicBuffer->m_portInfoLookup["Ethernet12"].state, PORT_INITIALIZING);
+        ASSERT_EQ(m_dynamicBuffer->m_portInfoLookup["Ethernet12"].effective_speed, "100000");
+
+        cableLengthTable.set("AZURE",
+                             {
+                                 {"Ethernet12", "5m"}
+                             });
+        HandleTable(cableLengthTable);
+        ASSERT_EQ(m_dynamicBuffer->m_portInfoLookup["Ethernet12"].state, PORT_READY);
+    }
+}

--- a/tests/mock_tests/buffermgrdyn_ut.cpp
+++ b/tests/mock_tests/buffermgrdyn_ut.cpp
@@ -786,6 +786,439 @@ namespace buffermgrdyn_test
     }
 
     /*
+     * Clear qos with reclaiming buffer
+     *
+     * To test clear qos flow with reclaiming buffer.
+     * 1. Init buffer manager as normal
+     * 2. Configure buffer for 2 ports with admin status being up and down respectively
+     * 3. Clear qos
+     * 4. Check whether all the buffer items have been removed
+     * 5. Repeat the flow from step 2 for two extra times:
+     *    - Check whether buffer manager works correctly after clear qos
+     *    - STATE_DB.BUFFER_MAX_PARAM is received before and after buffer items received
+     */
+    TEST_F(BufferMgrDynTest, BufferMgrTestClearQosReclaimingBuffer)
+    {
+        vector<FieldValueTuple> fieldValues;
+        vector<string> keys;
+        vector<string> skippedPools = {"", "ingress_lossless_pool", ""};
+        int round = 0;
+
+        SetUpReclaimingBuffer();
+        shared_ptr<vector<KeyOpFieldsValuesTuple>> zero_profile = make_shared<vector<KeyOpFieldsValuesTuple>>(zeroProfile);
+
+        InitDefaultLosslessParameter();
+        InitMmuSize();
+
+        StartBufferManager(zero_profile);
+
+        statePortTable.set("Ethernet0",
+                           {
+                               {"supported_speeds", "100000,50000,40000,25000,10000,1000"}
+                           });
+        InitPort("Ethernet0", "down");
+        InitPort("Ethernet2");
+        InitCableLength("Ethernet2", "5m");
+        auto expectedProfile = "pg_lossless_100000_5m_profile";
+        ASSERT_EQ(m_dynamicBuffer->m_portInfoLookup["Ethernet0"].state, PORT_ADMIN_DOWN);
+
+        SetPortInitDone();
+        for(auto &skippedPool : skippedPools)
+        {
+            // Call timer
+            m_dynamicBuffer->doTask(m_selectableTable);
+            ASSERT_EQ(m_dynamicBuffer->m_bufferPoolLookup.size(), 0);
+            InitBufferPool();
+            ASSERT_EQ(m_dynamicBuffer->m_bufferPoolLookup.size(), 3);
+            appBufferPoolTable.getKeys(keys);
+            ASSERT_EQ(keys.size(), 3);
+            for (auto i : testBufferPool)
+            {
+                CheckPool(m_dynamicBuffer->m_bufferPoolLookup[i.first], testBufferPool[i.first]);
+                fieldValues.clear();
+                appBufferPoolTable.get(i.first, fieldValues);
+                CheckPool(m_dynamicBuffer->m_bufferPoolLookup[i.first], fieldValues);
+            }
+
+            InitDefaultBufferProfile();
+            appBufferProfileTable.getKeys(keys);
+            ASSERT_EQ(keys.size(), 3);
+            ASSERT_EQ(m_dynamicBuffer->m_bufferProfileLookup.size(), 3);
+            for (auto i : testBufferProfile)
+            {
+                CheckProfile(m_dynamicBuffer->m_bufferProfileLookup[i.first], testBufferProfile[i.first]);
+                fieldValues.clear();
+                appBufferProfileTable.get(i.first, fieldValues);
+                CheckProfile(m_dynamicBuffer->m_bufferProfileLookup[i.first], fieldValues);
+            }
+
+            InitBufferQueue("Ethernet0|3-4", "egress_lossless_profile");
+            InitBufferQueue("Ethernet0|0-2", "egress_lossy_profile");
+            InitBufferPg("Ethernet0|0", "ingress_lossy_profile");
+            InitBufferPg("Ethernet0|3-4");
+            InitBufferProfileList("Ethernet0", "ingress_lossless_profile", bufferIngProfileListTable);
+            InitBufferProfileList("Ethernet0", "egress_lossless_profile,egress_lossy_profile", bufferEgrProfileListTable);
+
+            // Init buffer items for a normal port and check APPL_DB
+            InitBufferQueue("Ethernet2|3-4", "egress_lossless_profile");
+            InitBufferQueue("Ethernet2|0-2", "egress_lossy_profile");
+            InitBufferPg("Ethernet2|3-4");
+            InitBufferProfileList("Ethernet2", "ingress_lossless_profile", bufferIngProfileListTable);
+            InitBufferProfileList("Ethernet2", "egress_lossless_profile,egress_lossy_profile", bufferEgrProfileListTable);
+
+            fieldValues.clear();
+            ASSERT_TRUE(appBufferPgTable.get("Ethernet2:3-4", fieldValues));
+            CheckIfVectorsMatch(fieldValues, {{"profile", expectedProfile}});
+            fieldValues.clear();
+            ASSERT_TRUE(appBufferQueueTable.get("Ethernet2:0-2", fieldValues));
+            CheckIfVectorsMatch(fieldValues, {{"profile", "egress_lossy_profile"}});
+            fieldValues.clear();
+            ASSERT_TRUE(appBufferQueueTable.get("Ethernet2:3-4", fieldValues));
+            CheckIfVectorsMatch(fieldValues, {{"profile", "egress_lossless_profile"}});
+            fieldValues.clear();
+            ASSERT_TRUE(appBufferIngProfileListTable.get("Ethernet2", fieldValues));
+            CheckIfVectorsMatch(fieldValues, {{"profile_list", "ingress_lossless_profile"}});
+            fieldValues.clear();
+            ASSERT_TRUE(appBufferEgrProfileListTable.get("Ethernet2", fieldValues));
+            CheckIfVectorsMatch(fieldValues, {{"profile_list", "egress_lossless_profile,egress_lossy_profile"}});
+
+            // Buffer pools ready but the port is not ready to be reclaimed
+            m_dynamicBuffer->doTask(m_selectableTable);
+
+            // Push maximum buffer parameters for the port in order to make it ready to reclaim
+            if (round++ == 0)
+            {
+                // To simulate different sequences
+                // The 1st round: STATE_DB.PORT_TABLE is updated after buffer items ready
+                // The 2nd, 3rd rounds: before
+                stateBufferTable.set("Ethernet0",
+                                     {
+                                         {"max_priority_groups", "8"},
+                                         {"max_queues", "16"}
+                                     });
+                m_dynamicBuffer->addExistingData(&stateBufferTable);
+                static_cast<Orch *>(m_dynamicBuffer)->doTask();
+            }
+
+            //m_dynamicBuffer->m_waitApplyAdditionalZeroProfiles = 0;
+            m_dynamicBuffer->doTask(m_selectableTable);
+
+            // Check whether zero profiles and pool have been applied
+            appBufferPoolTable.getKeys(keys);
+            ASSERT_EQ(keys.size(), 4);
+            for (auto key : keys)
+            {
+                if (testBufferPool.find(key) == testBufferPool.end())
+                {
+                    fieldValues.clear();
+                    appBufferPoolTable.get(key, fieldValues);
+                    CheckIfVectorsMatch(fieldValues, zeroProfileMap[key]);
+                }
+            }
+
+            appBufferProfileTable.getKeys(keys);
+            for (auto key : keys)
+            {
+                if (testBufferProfile.find(key) == testBufferProfile.end())
+                {
+                    fieldValues.clear();
+                    appBufferProfileTable.get(key, fieldValues);
+                    if (zeroProfileMap.find(key) == zeroProfileMap.end())
+                        CheckIfVectorsMatch(fieldValues,
+                                            {
+                                                {"xon", ""},  // Due to the limitation of mock lua scricpt call,
+                                                {"xoff", ""}, // we can not calculate the number
+                                                {"size", ""}, // so expected value is the empty string
+                                                {"pool", "ingress_lossless_pool"},
+                                                {"dynamic_th", "0"}
+                                            });
+                    else
+                        CheckIfVectorsMatch(fieldValues, zeroProfileMap[key]);
+                }
+            }
+
+            fieldValues.clear();
+            ASSERT_TRUE(appBufferPgTable.get("Ethernet0:0", fieldValues));
+            CheckIfVectorsMatch(fieldValues, {{"profile", "ingress_lossy_pg_zero_profile"}});
+            ASSERT_FALSE(appBufferPgTable.get("Ethernet0:3-4", fieldValues));
+            fieldValues.clear();
+            ASSERT_TRUE(appBufferQueueTable.get("Ethernet0:0-2", fieldValues));
+            CheckIfVectorsMatch(fieldValues, {{"profile", "egress_lossy_zero_profile"}});
+            fieldValues.clear();
+            ASSERT_TRUE(appBufferQueueTable.get("Ethernet0:3-4", fieldValues));
+            CheckIfVectorsMatch(fieldValues, {{"profile", "egress_lossless_zero_profile"}});
+            fieldValues.clear();
+            ASSERT_TRUE(appBufferIngProfileListTable.get("Ethernet0", fieldValues));
+            CheckIfVectorsMatch(fieldValues, {{"profile_list", "ingress_lossless_zero_profile"}});
+            fieldValues.clear();
+            ASSERT_TRUE(appBufferEgrProfileListTable.get("Ethernet0", fieldValues));
+            CheckIfVectorsMatch(fieldValues, {{"profile_list", "egress_lossless_zero_profile,egress_lossy_zero_profile"}});
+
+            // Configured but not applied items. There is an extra delay
+            m_dynamicBuffer->m_waitApplyAdditionalZeroProfiles = 0;
+            m_dynamicBuffer->doTask(m_selectableTable);
+            fieldValues.clear();
+            ASSERT_TRUE(appBufferQueueTable.get("Ethernet0:5-15", fieldValues));
+            CheckIfVectorsMatch(fieldValues, {{"profile", "egress_lossy_zero_profile"}});
+
+            // Clear all qos tables
+            ClearBufferPool(skippedPool);
+            ClearBufferProfile();
+            ClearBufferObject("Ethernet0|0", CFG_BUFFER_PG_TABLE_NAME);
+            ClearBufferObject("Ethernet0|3-4", CFG_BUFFER_PG_TABLE_NAME);
+            ClearBufferObject("Ethernet2|3-4", CFG_BUFFER_PG_TABLE_NAME);
+            ClearBufferObject("Ethernet0|0-2", CFG_BUFFER_QUEUE_TABLE_NAME);
+            ClearBufferObject("Ethernet2|0-2", CFG_BUFFER_QUEUE_TABLE_NAME);
+            ClearBufferObject("Ethernet0|3-4", CFG_BUFFER_QUEUE_TABLE_NAME);
+            ClearBufferObject("Ethernet2|3-4", CFG_BUFFER_QUEUE_TABLE_NAME);
+            ClearBufferObject("Ethernet0", CFG_BUFFER_PORT_INGRESS_PROFILE_LIST_NAME);
+            ClearBufferObject("Ethernet2", CFG_BUFFER_PORT_INGRESS_PROFILE_LIST_NAME);
+            ClearBufferObject("Ethernet0", CFG_BUFFER_PORT_EGRESS_PROFILE_LIST_NAME);
+            ClearBufferObject("Ethernet2", CFG_BUFFER_PORT_EGRESS_PROFILE_LIST_NAME);
+
+            // Run timer
+            m_dynamicBuffer->doTask(m_selectableTable);
+
+            if (!skippedPool.empty())
+            {
+                // Clear the pool that was skipped in the previous step
+                // This is to simulate the case where all the pools are not removed in one-shot
+                ClearBufferPool("", skippedPool);
+                m_dynamicBuffer->doTask(m_selectableTable);
+            }
+
+            // All internal data and APPL_DB has been cleared
+            ASSERT_TRUE((appBufferPgTable.getKeys(keys), keys.empty()));
+            ASSERT_TRUE((appBufferQueueTable.getKeys(keys), keys.empty()));
+            ASSERT_TRUE((appBufferProfileTable.getKeys(keys), keys.empty()));
+            ASSERT_TRUE((appBufferPoolTable.getKeys(keys), keys.empty()));
+            ASSERT_TRUE((appBufferIngProfileListTable.getKeys(keys), keys.empty()));
+            ASSERT_TRUE((appBufferEgrProfileListTable.getKeys(keys), keys.empty()));
+            ASSERT_TRUE(m_dynamicBuffer->m_bufferPoolLookup.empty());
+            ASSERT_TRUE(m_dynamicBuffer->m_bufferProfileLookup.empty());
+            ASSERT_TRUE(m_dynamicBuffer->m_portPgLookup.empty());
+            ASSERT_TRUE(m_dynamicBuffer->m_portQueueLookup.empty());
+            ASSERT_TRUE(m_dynamicBuffer->m_portProfileListLookups[BUFFER_EGRESS].empty());
+            ASSERT_TRUE(m_dynamicBuffer->m_portProfileListLookups[BUFFER_INGRESS].empty());
+        }
+    }
+
+
+    /*
+     * Clear qos with reclaiming buffer sad flows
+     * Reclaiming buffer should be triggered via any single buffer item
+     */
+    TEST_F(BufferMgrDynTest, BufferMgrTestReclaimingBufferSadFlows)
+    {
+        vector<FieldValueTuple> fieldValues;
+        vector<string> keys;
+        vector<tuple<Table&, string, string, Table&, string, string>> bufferItems;
+
+        bufferItems.emplace_back(bufferPgTable, "Ethernet0:0", "ingress_lossy_profile", appBufferPgTable, "profile", "ingress_lossy_pg_zero_profile");
+        bufferItems.emplace_back(bufferPgTable, "Ethernet0:3-4", "NULL", appBufferPgTable, "", "");
+        bufferItems.emplace_back(bufferQueueTable, "Ethernet0:0-2", "egress_lossy_profile", appBufferQueueTable, "profile", "egress_lossy_zero_profile");
+        bufferItems.emplace_back(bufferQueueTable, "Ethernet0:3-4", "egress_lossless_profile", appBufferQueueTable, "profile", "egress_lossless_zero_profile");
+        bufferItems.emplace_back(bufferIngProfileListTable, "Ethernet0", "ingress_lossless_profile", appBufferIngProfileListTable, "profile_list", "ingress_lossless_zero_profile");
+        bufferItems.emplace_back(bufferEgrProfileListTable, "Ethernet0", "egress_lossless_profile,egress_lossy_profile", appBufferEgrProfileListTable, "profile_list", "egress_lossless_zero_profile,egress_lossy_zero_profile");
+
+        SetUpReclaimingBuffer();
+        shared_ptr<vector<KeyOpFieldsValuesTuple>> zero_profile = make_shared<vector<KeyOpFieldsValuesTuple>>(zeroProfile);
+
+        InitDefaultLosslessParameter();
+        InitMmuSize();
+
+        StartBufferManager(zero_profile);
+
+        stateBufferTable.set("Ethernet0",
+                             {
+                                 {"max_priority_groups", "8"},
+                                 {"max_queues", "16"}
+                             });
+        m_dynamicBuffer->addExistingData(&stateBufferTable);
+        static_cast<Orch *>(m_dynamicBuffer)->doTask();
+
+        InitPort("Ethernet0", "down");
+
+        ASSERT_EQ(m_dynamicBuffer->m_portInfoLookup["Ethernet0"].state, PORT_ADMIN_DOWN);
+
+        SetPortInitDone();
+        m_dynamicBuffer->doTask(m_selectableTable);
+
+        // After "config qos clear" the zero buffer profiles are unloaded
+        m_dynamicBuffer->unloadZeroPoolAndProfiles();
+
+        // Starts with empty buffer tables
+        for(auto &bufferItem : bufferItems)
+        {
+            auto &cfgTable = get<0>(bufferItem);
+            auto &key = get<1>(bufferItem);
+            auto &profile = get<2>(bufferItem);
+            auto &appTable = get<3>(bufferItem);
+            auto &fieldName = get<4>(bufferItem);
+            auto &expectedProfile = get<5>(bufferItem);
+
+            cfgTable.set(key,
+                         {
+                             {fieldName, profile}
+                         });
+            m_dynamicBuffer->addExistingData(&cfgTable);
+            static_cast<Orch *>(m_dynamicBuffer)->doTask();
+
+            ASSERT_FALSE(m_dynamicBuffer->m_bufferCompletelyInitialized);
+            ASSERT_FALSE(m_dynamicBuffer->m_zeroProfilesLoaded);
+            ASSERT_TRUE(m_dynamicBuffer->m_portInitDone);
+            ASSERT_TRUE(m_dynamicBuffer->m_pendingApplyZeroProfilePorts.find("Ethernet0") != m_dynamicBuffer->m_pendingApplyZeroProfilePorts.end());
+
+            InitBufferPool();
+            InitDefaultBufferProfile();
+
+            m_dynamicBuffer->doTask(m_selectableTable);
+
+            // Another doTask to ensure all the dependent tables have been drained
+            // after buffer pools and profiles have been drained
+            static_cast<Orch *>(m_dynamicBuffer)->doTask();
+
+            if (expectedProfile.empty())
+            {
+                ASSERT_FALSE(appTable.get(key, fieldValues));
+            }
+            else
+            {
+                ASSERT_TRUE(appTable.get(key, fieldValues));
+                CheckIfVectorsMatch(fieldValues, {{fieldName, expectedProfile}});
+            }
+
+            m_dynamicBuffer->m_waitApplyAdditionalZeroProfiles = 0;
+            m_dynamicBuffer->doTask(m_selectableTable);
+
+            ASSERT_TRUE(m_dynamicBuffer->m_pendingApplyZeroProfilePorts.empty());
+            ASSERT_TRUE(m_dynamicBuffer->m_bufferCompletelyInitialized);
+
+            // Simulate clear qos
+            ClearBufferPool();
+            ClearBufferProfile();
+
+            // Call timer
+            m_dynamicBuffer->doTask(m_selectableTable);
+        }
+    }
+
+    /*
+     * Port removing flow
+     */
+    TEST_F(BufferMgrDynTest, BufferMgrTestRemovePort)
+    {
+        vector<FieldValueTuple> fieldValues;
+        vector<string> keys;
+        vector<string> statuses = {"up", "down"};
+
+        // Prepare information that will be read at the beginning
+        InitDefaultLosslessParameter();
+        InitMmuSize();
+
+        shared_ptr<vector<KeyOpFieldsValuesTuple>> zero_profile = make_shared<vector<KeyOpFieldsValuesTuple>>(zeroProfile);
+        StartBufferManager(zero_profile);
+
+        SetPortInitDone();
+        // Timer will be called
+        m_dynamicBuffer->doTask(m_selectableTable);
+
+        InitBufferPool();
+        appBufferPoolTable.getKeys(keys);
+        ASSERT_EQ(keys.size(), 3);
+        InitDefaultBufferProfile();
+        appBufferProfileTable.getKeys(keys);
+        ASSERT_EQ(keys.size(), 3);
+        ASSERT_EQ(m_dynamicBuffer->m_bufferProfileLookup.size(), 3);
+
+        m_dynamicBuffer->m_bufferCompletelyInitialized = true;
+        m_dynamicBuffer->m_waitApplyAdditionalZeroProfiles = 0;
+        InitCableLength("Ethernet0", "5m");
+
+        for(auto status : statuses)
+        {
+            bool admin_up = (status == "up");
+
+            InitPort("Ethernet0", status);
+            ASSERT_TRUE(m_dynamicBuffer->m_portInfoLookup.find("Ethernet0") != m_dynamicBuffer->m_portInfoLookup.end());
+            ASSERT_EQ(m_dynamicBuffer->m_portInfoLookup["Ethernet0"].state, admin_up ? PORT_READY : PORT_ADMIN_DOWN);
+
+            // Init port buffer items
+            InitBufferQueue("Ethernet0|3-4", "egress_lossless_profile");
+            InitBufferProfileList("Ethernet0", "ingress_lossless_profile", bufferIngProfileListTable);
+            InitBufferPg("Ethernet0|3-4");
+            if (admin_up)
+            {
+                InitBufferProfileList("Ethernet0", "egress_lossless_profile,egress_lossy_profile", bufferEgrProfileListTable);
+
+                auto expectedProfile = "pg_lossless_100000_5m_profile";
+                CheckPg("Ethernet0", "Ethernet0:3-4", expectedProfile);
+                CheckQueue("Ethernet0", "Ethernet0:3-4", "egress_lossless_profile", true);
+                CheckProfileList("Ethernet0", true, "ingress_lossless_profile");
+                CheckProfileList("Ethernet0", false, "egress_lossless_profile,egress_lossy_profile");
+            }
+            else
+            {
+                InitBufferPg("Ethernet0|0", "ingress_lossy_profile");
+
+                stateBufferTable.set("Ethernet0",
+                                     {
+                                         {"max_priority_groups", "8"},
+                                         {"max_queues", "16"}
+                                     });
+                m_dynamicBuffer->addExistingData(&stateBufferTable);
+                static_cast<Orch *>(m_dynamicBuffer)->doTask();
+
+                // Make sure profile list is applied after maximum buffer parameter table
+                InitBufferProfileList("Ethernet0", "egress_lossless_profile,egress_lossy_profile", bufferEgrProfileListTable);
+
+                fieldValues.clear();
+                ASSERT_TRUE(appBufferPgTable.get("Ethernet0:0", fieldValues));
+                CheckIfVectorsMatch(fieldValues, {{"profile", "ingress_lossy_pg_zero_profile"}});
+
+                fieldValues.clear();
+                ASSERT_TRUE(appBufferQueueTable.get("Ethernet0:3-4", fieldValues));
+                CheckIfVectorsMatch(fieldValues, {{"profile", "egress_lossless_zero_profile"}});
+
+                fieldValues.clear();
+                ASSERT_TRUE(appBufferQueueTable.get("Ethernet0:0-2", fieldValues));
+                CheckIfVectorsMatch(fieldValues, {{"profile", "egress_lossy_zero_profile"}});
+
+                fieldValues.clear();
+                ASSERT_TRUE(appBufferQueueTable.get("Ethernet0:5-15", fieldValues));
+                CheckIfVectorsMatch(fieldValues, {{"profile", "egress_lossy_zero_profile"}});
+
+                fieldValues.clear();
+                ASSERT_TRUE(appBufferIngProfileListTable.get("Ethernet0", fieldValues));
+                CheckIfVectorsMatch(fieldValues, {{"profile_list", "ingress_lossless_zero_profile"}});
+
+                fieldValues.clear();
+                ASSERT_TRUE(appBufferEgrProfileListTable.get("Ethernet0", fieldValues));
+                CheckIfVectorsMatch(fieldValues, {{"profile_list", "egress_lossless_zero_profile,egress_lossy_zero_profile"}});
+
+                ClearBufferObject("Ethernet0|0", CFG_BUFFER_PG_TABLE_NAME);
+            }
+
+            // Remove port
+            ClearBufferObject("Ethernet0", CFG_PORT_TABLE_NAME);
+            ASSERT_FALSE(m_dynamicBuffer->m_portPgLookup.empty());
+            ClearBufferObject("Ethernet0", CFG_BUFFER_PORT_INGRESS_PROFILE_LIST_NAME);
+            ClearBufferObject("Ethernet0", CFG_BUFFER_PORT_EGRESS_PROFILE_LIST_NAME);
+            ClearBufferObject("Ethernet0|3-4", CFG_BUFFER_PG_TABLE_NAME);
+            ClearBufferObject("Ethernet0|3-4", CFG_BUFFER_QUEUE_TABLE_NAME);
+            static_cast<Orch *>(m_dynamicBuffer)->doTask();
+            ASSERT_TRUE(m_dynamicBuffer->m_portPgLookup.empty());
+            ASSERT_TRUE(m_dynamicBuffer->m_portQueueLookup.empty());
+            ASSERT_TRUE(m_dynamicBuffer->m_portProfileListLookups[BUFFER_INGRESS].empty());
+            ASSERT_TRUE(m_dynamicBuffer->m_portProfileListLookups[BUFFER_EGRESS].empty());
+            ASSERT_TRUE((appBufferPgTable.getKeys(keys), keys.empty()));
+            ASSERT_TRUE((appBufferQueueTable.getKeys(keys), keys.empty()));
+            ASSERT_TRUE((appBufferIngProfileListTable.getKeys(keys), keys.empty()));
+            ASSERT_TRUE((appBufferEgrProfileListTable.getKeys(keys), keys.empty()));
+        }
+    }
+
+    /*
      * Port configuration flow
      * Port table items are received in different order
      */

--- a/tests/mock_tests/copporch_ut.cpp
+++ b/tests/mock_tests/copporch_ut.cpp
@@ -203,7 +203,11 @@ namespace copporch_test
             // PolicerOrch
             //
 
-            auto policerOrch = new PolicerOrch(this->configDb.get(), CFG_POLICER_TABLE_NAME);
+            vector<TableConnector> policer_tables = {
+                TableConnector(this->configDb.get(), CFG_POLICER_TABLE_NAME),
+                TableConnector(this->configDb.get(), CFG_PORT_STORM_CONTROL_TABLE_NAME)
+            };
+            auto policerOrch = new PolicerOrch(policer_tables, gPortsOrch);
             gDirectory.set(policerOrch);
             resourcesList.push_back(policerOrch);
 

--- a/tests/mock_tests/fdborch/flush_syncd_notif_ut.cpp
+++ b/tests/mock_tests/fdborch/flush_syncd_notif_ut.cpp
@@ -1,0 +1,424 @@
+#include "../ut_helper.h"
+#include "../mock_orchagent_main.h"
+#include "../mock_table.h"
+#include "port.h"
+#define private public // Need to modify internal cache
+#include "portsorch.h"
+#include "fdborch.h"
+#include "crmorch.h"
+#undef private
+
+#define ETH0 "Ethernet0"
+#define VLAN40 "Vlan40"
+
+extern redisReply *mockReply;
+extern CrmOrch*  gCrmOrch;
+
+/*
+Test Fixture 
+*/
+namespace fdb_syncd_flush_test
+{
+    struct FdbOrchTest : public ::testing::Test
+    {   
+        std::shared_ptr<swss::DBConnector> m_config_db;
+        std::shared_ptr<swss::DBConnector> m_app_db;
+        std::shared_ptr<swss::DBConnector> m_state_db;
+        std::shared_ptr<swss::DBConnector> m_asic_db;
+        std::shared_ptr<swss::DBConnector> m_chassis_app_db;
+        std::shared_ptr<PortsOrch> m_portsOrch;
+        std::shared_ptr<FdbOrch> m_fdborch;
+
+        virtual void SetUp() override
+        {   
+
+            testing_db::reset();
+
+            map<string, string> profile = {
+                { "SAI_VS_SWITCH_TYPE", "SAI_VS_SWITCH_TYPE_BCM56850" },
+                { "KV_DEVICE_MAC_ADDRESS", "20:03:04:05:06:00" }
+            };
+
+            ut_helper::initSaiApi(profile);
+            
+            /* Create Switch */
+            sai_attribute_t attr;
+            attr.id = SAI_SWITCH_ATTR_INIT_SWITCH;
+            attr.value.booldata = true;
+            auto status = sai_switch_api->create_switch(&gSwitchId, 1, &attr);
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+            m_config_db = std::make_shared<swss::DBConnector>("CONFIG_DB", 0);
+            m_app_db = std::make_shared<swss::DBConnector>("APPL_DB", 0);
+            m_state_db = make_shared<swss::DBConnector>("STATE_DB", 0);
+            m_asic_db = std::make_shared<swss::DBConnector>("ASIC_DB", 0);
+
+            // Construct dependencies
+            // 1) Portsorch
+            const int portsorch_base_pri = 40;
+
+            vector<table_name_with_pri_t> ports_tables = {
+                { APP_PORT_TABLE_NAME, portsorch_base_pri + 5 },
+                { APP_VLAN_TABLE_NAME, portsorch_base_pri + 2 },
+                { APP_VLAN_MEMBER_TABLE_NAME, portsorch_base_pri },
+                { APP_LAG_TABLE_NAME, portsorch_base_pri + 4 },
+                { APP_LAG_MEMBER_TABLE_NAME, portsorch_base_pri }
+            };
+
+            m_portsOrch = std::make_shared<PortsOrch>(m_app_db.get(), m_state_db.get(), ports_tables, m_chassis_app_db.get());
+
+            // 2) Crmorch
+            ASSERT_EQ(gCrmOrch, nullptr);
+            gCrmOrch = new CrmOrch(m_config_db.get(), CFG_CRM_TABLE_NAME);
+            
+             // Construct fdborch
+            vector<table_name_with_pri_t> app_fdb_tables = {
+                { APP_FDB_TABLE_NAME,        FdbOrch::fdborch_pri},
+                { APP_VXLAN_FDB_TABLE_NAME,  FdbOrch::fdborch_pri},
+                { APP_MCLAG_FDB_TABLE_NAME,  FdbOrch::fdborch_pri}
+            };
+
+            TableConnector stateDbFdb(m_state_db.get(), STATE_FDB_TABLE_NAME);
+            TableConnector stateMclagDbFdb(m_state_db.get(), STATE_MCLAG_REMOTE_FDB_TABLE_NAME);
+
+            m_fdborch = std::make_shared<FdbOrch>(m_app_db.get(), 
+                                                  app_fdb_tables, 
+                                                  stateDbFdb,
+                                                  stateMclagDbFdb, 
+                                                  m_portsOrch.get());
+        }
+
+        virtual void TearDown() override {
+            delete gCrmOrch;
+            gCrmOrch = nullptr;
+
+            ut_helper::uninitSaiApi();
+        }
+    };
+
+    /* Helper Methods */
+    void setUpVlan(PortsOrch* m_portsOrch){
+        /* Updates portsOrch internal cache for Vlan40 */
+        std::string alias = VLAN40;
+        sai_object_id_t oid = 0x26000000000796;
+
+        Port vlan(alias, Port::VLAN);
+        vlan.m_vlan_info.vlan_oid = oid;
+        vlan.m_vlan_info.vlan_id = 40;
+        vlan.m_members = set<string>();
+
+        m_portsOrch->m_portList[alias] = vlan;
+        m_portsOrch->m_port_ref_count[alias] = 0;
+        m_portsOrch->saiOidToAlias[oid] = alias;
+    }
+
+    void setUpPort(PortsOrch* m_portsOrch){
+        /* Updates portsOrch internal cache for Ethernet0 */
+        std::string alias = ETH0;
+        sai_object_id_t oid = 0x10000000004a4;
+
+        Port port(alias, Port::PHY);
+        port.m_index = 1;
+        port.m_port_id = oid;
+        port.m_hif_id = 0xd00000000056e;
+
+        m_portsOrch->m_portList[alias] = port;
+        m_portsOrch->saiOidToAlias[oid] =  alias;
+    }
+
+    void setUpVlanMember(PortsOrch* m_portsOrch){
+        /* Updates portsOrch internal cache for adding Ethernet0 into Vlan40 */
+        sai_object_id_t bridge_port_id = 0x3a000000002c33;
+        
+        /* Add Bridge Port */
+        m_portsOrch->m_portList[ETH0].m_bridge_port_id = bridge_port_id;
+        m_portsOrch->saiOidToAlias[bridge_port_id] = ETH0;
+        m_portsOrch->m_portList[VLAN40].m_members.insert(ETH0);
+    }
+
+    void triggerUpdate(FdbOrch* m_fdborch,
+                       sai_fdb_event_t type,
+                       vector<uint8_t> mac_addr,
+                       sai_object_id_t bridge_port_id,
+                       sai_object_id_t bv_id){
+        sai_fdb_entry_t entry;
+        for (int i = 0; i < (int)mac_addr.size(); i++){
+            *(entry.mac_address+i) = mac_addr[i];
+        }
+        entry.bv_id = bv_id;
+        m_fdborch->update(type, &entry, bridge_port_id);
+    }
+}
+
+namespace fdb_syncd_flush_test
+{
+    /* Test Consolidated Flush Per Vlan and Per Port */
+    TEST_F(FdbOrchTest, ConsolidatedFlushVlanandPort)
+    {   
+        ASSERT_NE(m_portsOrch, nullptr);
+        setUpVlan(m_portsOrch.get());
+        setUpPort(m_portsOrch.get());
+        ASSERT_NE(m_portsOrch->m_portList.find(VLAN40), m_portsOrch->m_portList.end());
+        ASSERT_NE(m_portsOrch->m_portList.find(ETH0), m_portsOrch->m_portList.end());
+        setUpVlanMember(m_portsOrch.get());
+
+        /* Event 1: Learn a dynamic FDB Entry */
+        // 7c:fe:90:12:22:ec
+        vector<uint8_t> mac_addr = {124, 254, 144, 18, 34, 236};
+        triggerUpdate(m_fdborch.get(), SAI_FDB_EVENT_LEARNED, mac_addr, m_portsOrch->m_portList[ETH0].m_bridge_port_id,
+                      m_portsOrch->m_portList[VLAN40].m_vlan_info.vlan_oid);
+
+        string port;
+        string entry_type;
+
+        /* Make sure fdb_count is incremented as expected */
+        ASSERT_EQ(m_portsOrch->m_portList[VLAN40].m_fdb_count, 1);
+        ASSERT_EQ(m_portsOrch->m_portList[ETH0].m_fdb_count, 1);
+
+        /* Make sure state db is updated as expected */
+        ASSERT_EQ(m_fdborch->m_fdbStateTable.hget("Vlan40:7c:fe:90:12:22:ec", "port", port), true);
+        ASSERT_EQ(m_fdborch->m_fdbStateTable.hget("Vlan40:7c:fe:90:12:22:ec", "type", entry_type), true);
+        
+        ASSERT_EQ(port, "Ethernet0");
+        ASSERT_EQ(entry_type, "dynamic");
+
+        /* Event 2: Generate a FDB Flush per port and per vlan */
+        vector<uint8_t> flush_mac_addr = {0, 0, 0, 0, 0, 0};
+        triggerUpdate(m_fdborch.get(), SAI_FDB_EVENT_FLUSHED, flush_mac_addr, m_portsOrch->m_portList[ETH0].m_bridge_port_id,
+                      m_portsOrch->m_portList[VLAN40].m_vlan_info.vlan_oid);
+
+        /* make sure fdb_counters are decremented */
+        ASSERT_EQ(m_portsOrch->m_portList[VLAN40].m_fdb_count, 0);
+        ASSERT_EQ(m_portsOrch->m_portList[ETH0].m_fdb_count, 0);
+
+        /* Make sure state db is cleared */
+        ASSERT_EQ(m_fdborch->m_fdbStateTable.hget("Vlan40:7c:fe:90:12:22:ec", "port", port), false);
+        ASSERT_EQ(m_fdborch->m_fdbStateTable.hget("Vlan40:7c:fe:90:12:22:ec", "type", entry_type), false);
+    }
+
+    /* Test Consolidated Flush All */
+    TEST_F(FdbOrchTest, ConsolidatedFlushAll)
+    {   
+        ASSERT_NE(m_portsOrch, nullptr);
+        setUpVlan(m_portsOrch.get());
+        setUpPort(m_portsOrch.get());
+        ASSERT_NE(m_portsOrch->m_portList.find(VLAN40), m_portsOrch->m_portList.end());
+        ASSERT_NE(m_portsOrch->m_portList.find(ETH0), m_portsOrch->m_portList.end());
+        setUpVlanMember(m_portsOrch.get());
+
+        /* Event 1: Learn a dynamic FDB Entry */
+        // 7c:fe:90:12:22:ec
+        vector<uint8_t> mac_addr = {124, 254, 144, 18, 34, 236};
+        triggerUpdate(m_fdborch.get(), SAI_FDB_EVENT_LEARNED, mac_addr, m_portsOrch->m_portList[ETH0].m_bridge_port_id,
+                      m_portsOrch->m_portList[VLAN40].m_vlan_info.vlan_oid);
+        
+        string port;
+        string entry_type;
+
+        /* Make sure fdb_count is incremented as expected */
+        ASSERT_EQ(m_portsOrch->m_portList[VLAN40].m_fdb_count, 1);
+        ASSERT_EQ(m_portsOrch->m_portList[ETH0].m_fdb_count, 1);
+
+        /* Make sure state db is updated as expected */
+        ASSERT_EQ(m_fdborch->m_fdbStateTable.hget("Vlan40:7c:fe:90:12:22:ec", "port", port), true);
+        ASSERT_EQ(m_fdborch->m_fdbStateTable.hget("Vlan40:7c:fe:90:12:22:ec", "type", entry_type), true);
+        
+        ASSERT_EQ(port, "Ethernet0");
+        ASSERT_EQ(entry_type, "dynamic");
+
+        /* Event2: Send a Consolidated Flush response from syncd */
+        vector<uint8_t> flush_mac_addr = {0, 0, 0, 0, 0, 0};
+        triggerUpdate(m_fdborch.get(), SAI_FDB_EVENT_FLUSHED, flush_mac_addr, SAI_NULL_OBJECT_ID,
+                      SAI_NULL_OBJECT_ID);
+
+        /* make sure fdb_counters are decremented */
+        ASSERT_EQ(m_portsOrch->m_portList[VLAN40].m_fdb_count, 0);
+        ASSERT_EQ(m_portsOrch->m_portList[ETH0].m_fdb_count, 0);
+
+        /* Make sure state db is cleared */
+        ASSERT_EQ(m_fdborch->m_fdbStateTable.hget("Vlan40:7c:fe:90:12:22:ec", "port", port), false);
+        ASSERT_EQ(m_fdborch->m_fdbStateTable.hget("Vlan40:7c:fe:90:12:22:ec", "type", entry_type), false);
+    }
+
+    /* Test Consolidated Flush per VLAN BV_ID */
+    TEST_F(FdbOrchTest, ConsolidatedFlushVlan)
+    {   
+        ASSERT_NE(m_portsOrch, nullptr);
+        setUpVlan(m_portsOrch.get());
+        setUpPort(m_portsOrch.get());
+        ASSERT_NE(m_portsOrch->m_portList.find(VLAN40), m_portsOrch->m_portList.end());
+        ASSERT_NE(m_portsOrch->m_portList.find(ETH0), m_portsOrch->m_portList.end());
+        setUpVlanMember(m_portsOrch.get());
+
+        /* Event 1: Learn a dynamic FDB Entry */
+        // 7c:fe:90:12:22:ec
+        vector<uint8_t> mac_addr = {124, 254, 144, 18, 34, 236};
+        triggerUpdate(m_fdborch.get(), SAI_FDB_EVENT_LEARNED, mac_addr, m_portsOrch->m_portList[ETH0].m_bridge_port_id,
+                      m_portsOrch->m_portList[VLAN40].m_vlan_info.vlan_oid);
+        
+        string port;
+        string entry_type;
+
+        /* Make sure fdb_count is incremented as expected */
+        ASSERT_EQ(m_portsOrch->m_portList[VLAN40].m_fdb_count, 1);
+        ASSERT_EQ(m_portsOrch->m_portList[ETH0].m_fdb_count, 1);
+
+        /* Make sure state db is updated as expected */
+        ASSERT_EQ(m_fdborch->m_fdbStateTable.hget("Vlan40:7c:fe:90:12:22:ec", "port", port), true);
+        ASSERT_EQ(m_fdborch->m_fdbStateTable.hget("Vlan40:7c:fe:90:12:22:ec", "type", entry_type), true);
+        
+        ASSERT_EQ(port, "Ethernet0");
+        ASSERT_EQ(entry_type, "dynamic");
+
+        /* Event2: Send a Consolidated Flush response from syncd for vlan */
+        vector<uint8_t> flush_mac_addr = {0, 0, 0, 0, 0, 0};
+        triggerUpdate(m_fdborch.get(), SAI_FDB_EVENT_FLUSHED, flush_mac_addr, SAI_NULL_OBJECT_ID,
+                      m_portsOrch->m_portList[VLAN40].m_vlan_info.vlan_oid);
+
+        /* make sure fdb_counters are decremented */
+        ASSERT_EQ(m_portsOrch->m_portList[VLAN40].m_fdb_count, 0);
+        ASSERT_EQ(m_portsOrch->m_portList[ETH0].m_fdb_count, 0);
+
+        /* Make sure state db is cleared */
+        ASSERT_EQ(m_fdborch->m_fdbStateTable.hget("Vlan40:7c:fe:90:12:22:ec", "port", port), false);
+        ASSERT_EQ(m_fdborch->m_fdbStateTable.hget("Vlan40:7c:fe:90:12:22:ec", "type", entry_type), false);
+    }
+
+    /* Test Consolidated Flush per bridge port id */
+    TEST_F(FdbOrchTest, ConsolidatedFlushPort)
+    {   
+        ASSERT_NE(m_portsOrch, nullptr);
+        setUpVlan(m_portsOrch.get());
+        setUpPort(m_portsOrch.get());
+        ASSERT_NE(m_portsOrch->m_portList.find(VLAN40), m_portsOrch->m_portList.end());
+        ASSERT_NE(m_portsOrch->m_portList.find(ETH0), m_portsOrch->m_portList.end());
+        setUpVlanMember(m_portsOrch.get());
+
+        /* Event 1: Learn a dynamic FDB Entry */
+        // 7c:fe:90:12:22:ec
+        vector<uint8_t> mac_addr = {124, 254, 144, 18, 34, 236};
+        triggerUpdate(m_fdborch.get(), SAI_FDB_EVENT_LEARNED, mac_addr, m_portsOrch->m_portList[ETH0].m_bridge_port_id,
+                      m_portsOrch->m_portList[VLAN40].m_vlan_info.vlan_oid);
+        
+        string port;
+        string entry_type;
+
+        /* Make sure fdb_count is incremented as expected */
+        ASSERT_EQ(m_portsOrch->m_portList[VLAN40].m_fdb_count, 1);
+        ASSERT_EQ(m_portsOrch->m_portList[ETH0].m_fdb_count, 1);
+
+        /* Make sure state db is updated as expected */
+        ASSERT_EQ(m_fdborch->m_fdbStateTable.hget("Vlan40:7c:fe:90:12:22:ec", "port", port), true);
+        ASSERT_EQ(m_fdborch->m_fdbStateTable.hget("Vlan40:7c:fe:90:12:22:ec", "type", entry_type), true);
+        
+        ASSERT_EQ(port, "Ethernet0");
+        ASSERT_EQ(entry_type, "dynamic");
+
+        /* Event2: Send a Consolidated Flush response from syncd for a port */
+        vector<uint8_t> flush_mac_addr = {0, 0, 0, 0, 0, 0};
+        triggerUpdate(m_fdborch.get(), SAI_FDB_EVENT_FLUSHED, flush_mac_addr, m_portsOrch->m_portList[ETH0].m_bridge_port_id,
+                      SAI_NULL_OBJECT_ID);
+
+        /* make sure fdb_counters are decremented */
+        ASSERT_EQ(m_portsOrch->m_portList[VLAN40].m_fdb_count, 0);
+        ASSERT_EQ(m_portsOrch->m_portList[ETH0].m_fdb_count, 0);
+
+        /* Make sure state db is cleared */
+        ASSERT_EQ(m_fdborch->m_fdbStateTable.hget("Vlan40:7c:fe:90:12:22:ec", "port", port), false);
+        ASSERT_EQ(m_fdborch->m_fdbStateTable.hget("Vlan40:7c:fe:90:12:22:ec", "type", entry_type), false);
+    }
+
+    //* Test Consolidated Flush Per Vlan and Per Port, but the bridge_port_id from the internal cache is already deleted */
+    TEST_F(FdbOrchTest, ConsolidatedFlushVlanandPortBridgeportDeleted)
+    {
+        ASSERT_NE(m_portsOrch, nullptr);
+        setUpVlan(m_portsOrch.get());
+        setUpPort(m_portsOrch.get());
+        ASSERT_NE(m_portsOrch->m_portList.find(VLAN40), m_portsOrch->m_portList.end());
+        ASSERT_NE(m_portsOrch->m_portList.find(ETH0), m_portsOrch->m_portList.end());
+        setUpVlanMember(m_portsOrch.get());
+
+        /* Event 1: Learn a dynamic FDB Entry */
+        // 7c:fe:90:12:22:ec
+        vector<uint8_t> mac_addr = {124, 254, 144, 18, 34, 236};
+        triggerUpdate(m_fdborch.get(), SAI_FDB_EVENT_LEARNED, mac_addr, m_portsOrch->m_portList[ETH0].m_bridge_port_id,
+                      m_portsOrch->m_portList[VLAN40].m_vlan_info.vlan_oid);
+
+        string port;
+        string entry_type;
+
+        /* Make sure fdb_count is incremented as expected */
+        ASSERT_EQ(m_portsOrch->m_portList[VLAN40].m_fdb_count, 1);
+        ASSERT_EQ(m_portsOrch->m_portList[ETH0].m_fdb_count, 1);
+
+        /* Make sure state db is updated as expected */
+        ASSERT_EQ(m_fdborch->m_fdbStateTable.hget("Vlan40:7c:fe:90:12:22:ec", "port", port), true);
+        ASSERT_EQ(m_fdborch->m_fdbStateTable.hget("Vlan40:7c:fe:90:12:22:ec", "type", entry_type), true);
+
+        ASSERT_EQ(port, "Ethernet0");
+        ASSERT_EQ(entry_type, "dynamic");
+
+        auto bridge_port_oid = m_portsOrch->m_portList[ETH0].m_bridge_port_id;
+
+        /* Delete the bridge_port_oid in the internal OA cache */
+        m_portsOrch->m_portList[ETH0].m_bridge_port_id = SAI_NULL_OBJECT_ID;
+        m_portsOrch->saiOidToAlias.erase(bridge_port_oid);
+
+        /* Event 2: Generate a FDB Flush per port and per vlan */
+        vector<uint8_t> flush_mac_addr = {0, 0, 0, 0, 0, 0};
+        triggerUpdate(m_fdborch.get(), SAI_FDB_EVENT_FLUSHED, flush_mac_addr, bridge_port_oid,
+                      m_portsOrch->m_portList[VLAN40].m_vlan_info.vlan_oid);
+
+        /* make sure fdb_counter for Vlan is decremented */
+        ASSERT_EQ(m_portsOrch->m_portList[VLAN40].m_fdb_count, 0);
+        ASSERT_EQ(m_portsOrch->m_portList[ETH0].m_fdb_count, 0);
+
+        /* Make sure state db is cleared */
+        ASSERT_EQ(m_fdborch->m_fdbStateTable.hget("Vlan40:7c:fe:90:12:22:ec", "port", port), false);
+        ASSERT_EQ(m_fdborch->m_fdbStateTable.hget("Vlan40:7c:fe:90:12:22:ec", "type", entry_type), false);
+    }
+
+    /* Test Flush Per Vlan and Per Port */
+    TEST_F(FdbOrchTest, NonConsolidatedFlushVlanandPort)
+    {   
+        ASSERT_NE(m_portsOrch, nullptr);
+        setUpVlan(m_portsOrch.get());
+        setUpPort(m_portsOrch.get());
+        ASSERT_NE(m_portsOrch->m_portList.find(VLAN40), m_portsOrch->m_portList.end());
+        ASSERT_NE(m_portsOrch->m_portList.find(ETH0), m_portsOrch->m_portList.end());
+        setUpVlanMember(m_portsOrch.get());
+
+        /* Event 1: Learn a dynamic FDB Entry */
+        // 7c:fe:90:12:22:ec
+        vector<uint8_t> mac_addr = {124, 254, 144, 18, 34, 236};
+        triggerUpdate(m_fdborch.get(), SAI_FDB_EVENT_LEARNED, mac_addr, m_portsOrch->m_portList[ETH0].m_bridge_port_id,
+                      m_portsOrch->m_portList[VLAN40].m_vlan_info.vlan_oid);
+
+        string port;
+        string entry_type;
+
+        /* Make sure fdb_count is incremented as expected */
+        ASSERT_EQ(m_portsOrch->m_portList[VLAN40].m_fdb_count, 1);
+        ASSERT_EQ(m_portsOrch->m_portList[ETH0].m_fdb_count, 1);
+
+        /* Make sure state db is updated as expected */
+        ASSERT_EQ(m_fdborch->m_fdbStateTable.hget("Vlan40:7c:fe:90:12:22:ec", "port", port), true);
+        ASSERT_EQ(m_fdborch->m_fdbStateTable.hget("Vlan40:7c:fe:90:12:22:ec", "type", entry_type), true);
+        
+        ASSERT_EQ(port, "Ethernet0");
+        ASSERT_EQ(entry_type, "dynamic");
+
+        /* Event 2: Generate a non-consilidated FDB Flush per port and per vlan */
+        vector<uint8_t> flush_mac_addr = {124, 254, 144, 18, 34, 236};
+        triggerUpdate(m_fdborch.get(), SAI_FDB_EVENT_FLUSHED, flush_mac_addr, m_portsOrch->m_portList[ETH0].m_bridge_port_id,
+                      m_portsOrch->m_portList[VLAN40].m_vlan_info.vlan_oid);
+
+        /* make sure fdb_counters are decremented */
+        ASSERT_EQ(m_portsOrch->m_portList[VLAN40].m_fdb_count, 0);
+        ASSERT_EQ(m_portsOrch->m_portList[ETH0].m_fdb_count, 0);
+
+        /* Make sure state db is cleared */
+        ASSERT_EQ(m_fdborch->m_fdbStateTable.hget("Vlan40:7c:fe:90:12:22:ec", "port", port), false);
+        ASSERT_EQ(m_fdborch->m_fdbStateTable.hget("Vlan40:7c:fe:90:12:22:ec", "type", entry_type), false);
+    }
+}

--- a/tests/mock_tests/intfmgrd/add_ipv6_prefix_ut.cpp
+++ b/tests/mock_tests/intfmgrd/add_ipv6_prefix_ut.cpp
@@ -1,0 +1,117 @@
+#include "gtest/gtest.h"
+#include <iostream>
+#include <fstream>  
+#include <unistd.h>
+#include <sys/stat.h>
+#include "../mock_table.h"
+#include "warm_restart.h"
+#define private public 
+#include "intfmgr.h"
+#undef private
+
+/* Override this pointer for custom behavior */
+int (*callback)(const std::string &cmd, std::string &stdout) = nullptr;
+std::vector<std::string> mockCallArgs;
+
+namespace swss {
+    int exec(const std::string &cmd, std::string &stdout)
+    {
+        mockCallArgs.push_back(cmd);
+        return callback(cmd, stdout);
+    }
+}
+
+bool Ethernet0IPv6Set = false;
+
+int cb(const std::string &cmd, std::string &stdout){
+    if (cmd == "sysctl -w net.ipv6.conf.\"Ethernet0\".disable_ipv6=0") Ethernet0IPv6Set = true;
+    else if (cmd.find("/sbin/ip -6 address \"add\"") == 0) {
+        return Ethernet0IPv6Set ? 0 : 2;
+    }
+    else {
+        return 0;
+    }
+    return 0;
+}
+
+// Test Fixture
+namespace add_ipv6_prefix_ut
+{
+    struct IntfMgrTest : public ::testing::Test
+    {
+        std::shared_ptr<swss::DBConnector> m_config_db;
+        std::shared_ptr<swss::DBConnector> m_app_db;
+        std::shared_ptr<swss::DBConnector> m_state_db;
+        std::vector<std::string> cfg_intf_tables;
+        
+        virtual void SetUp() override
+        {   
+            testing_db::reset();
+            m_config_db = std::make_shared<swss::DBConnector>("CONFIG_DB", 0);
+            m_app_db = std::make_shared<swss::DBConnector>("APPL_DB", 0);
+            m_state_db = std::make_shared<swss::DBConnector>("STATE_DB", 0);
+            
+            swss::WarmStart::initialize("intfmgrd", "swss");
+
+            std::vector<std::string> tables = {
+                CFG_INTF_TABLE_NAME,
+                CFG_LAG_INTF_TABLE_NAME,
+                CFG_VLAN_INTF_TABLE_NAME,
+                CFG_LOOPBACK_INTERFACE_TABLE_NAME,
+                CFG_VLAN_SUB_INTF_TABLE_NAME,
+                CFG_VOQ_INBAND_INTERFACE_TABLE_NAME,
+            };
+            cfg_intf_tables = tables;
+            mockCallArgs.clear();
+            callback = cb;
+        }
+    };
+
+    TEST_F(IntfMgrTest, testSettingIpv6Flag){
+        Ethernet0IPv6Set = false;
+        swss::IntfMgr intfmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_intf_tables);
+        /* Set portStateTable */
+        std::vector<swss::FieldValueTuple> values;
+        values.emplace_back("state", "ok");
+        intfmgr.m_statePortTable.set("Ethernet0", values, "SET", "");
+        /* Set m_stateIntfTable */
+        values.clear();
+        values.emplace_back("vrf", "");
+        intfmgr.m_stateIntfTable.set("Ethernet0", values, "SET", "");
+        /* Set Ipv6 prefix */
+        const std::vector<std::string>& keys = {"Ethernet0", "2001::8/64"};
+        const std::vector<swss::FieldValueTuple> data;
+        intfmgr.doIntfAddrTask(keys, data, "SET");
+        int ip_cmd_called = 0;
+        for (auto cmd : mockCallArgs){
+            if (cmd.find("/sbin/ip -6 address \"add\"") == 0){
+                ip_cmd_called++;
+            }
+        }
+        ASSERT_EQ(ip_cmd_called, 2);
+    }
+
+    TEST_F(IntfMgrTest, testNoSettingIpv6Flag){
+        Ethernet0IPv6Set = true; // Assuming it is already set by SDK
+        swss::IntfMgr intfmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_intf_tables);
+        /* Set portStateTable */
+        std::vector<swss::FieldValueTuple> values;
+        values.emplace_back("state", "ok");
+        intfmgr.m_statePortTable.set("Ethernet0", values, "SET", "");
+        /* Set m_stateIntfTable */
+        values.clear();
+        values.emplace_back("vrf", "");
+        intfmgr.m_stateIntfTable.set("Ethernet0", values, "SET", "");
+        /* Set Ipv6 prefix */
+        const std::vector<std::string>& keys = {"Ethernet0", "2001::8/64"};
+        const std::vector<swss::FieldValueTuple> data;
+        intfmgr.doIntfAddrTask(keys, data, "SET");
+        int ip_cmd_called = 0;
+        for (auto cmd : mockCallArgs){
+            if (cmd.find("/sbin/ip -6 address \"add\"") == 0){
+                ip_cmd_called++;
+            }
+        }
+        ASSERT_EQ(ip_cmd_called, 1);
+    }
+}

--- a/tests/mock_tests/mock_table.cpp
+++ b/tests/mock_tests/mock_table.cpp
@@ -114,4 +114,12 @@ namespace swss
             iter->second.swap(new_values);
         }
     }
+
+    void ProducerStateTable::del(const std::string &key,
+                                 const std::string &op,
+                                 const std::string &prefix)
+    {
+        auto &table = gDB[m_pipe->getDbId()][getTableName()];
+        table.erase(key);
+    }
 }

--- a/tests/mock_tests/mock_table.cpp
+++ b/tests/mock_tests/mock_table.cpp
@@ -73,6 +73,15 @@ namespace swss
             keys.push_back(it.first);
         }
     }
+  
+ 
+    void Table::del(const std::string &key, const std::string& /* op */, const std::string& /*prefix*/)
+    {
+        auto table = gDB[m_pipe->getDbId()].find(getTableName());
+        if (table != gDB[m_pipe->getDbId()].end()){
+            table->second.erase(key);
+        }
+    }
 
     void ProducerStateTable::set(const std::string &key,
                                  const std::vector<FieldValueTuple> &values,
@@ -105,13 +114,4 @@ namespace swss
             iter->second.swap(new_values);
         }
     }
-
-    void ProducerStateTable::del(const std::string &key,
-                                 const std::string &op,
-                                 const std::string &prefix)
-    {
-        auto &table = gDB[m_pipe->getDbId()][getTableName()];
-        table.erase(key);
-    }
-
 }

--- a/tests/p4rt/test_l3.py
+++ b/tests/p4rt/test_l3.py
@@ -262,7 +262,7 @@ class TestP4RTL3(object):
 
         # Verify that P4RT key to OID count is same as the original count.
         status, fvs = key_to_oid_helper.get_db_info()
-        assert status == True
+        assert status == False
         assert len(fvs) == len(original_key_oid_info)
 
         # Query application database for route entries.
@@ -651,7 +651,7 @@ class TestP4RTL3(object):
 
         # Verify that P4RT key to OID count is same as original count.
         status, fvs = key_to_oid_helper.get_db_info()
-        assert status == True
+        assert status == False
         assert len(fvs) == len(original_key_oid_info)
 
         # Query application database for route entries.
@@ -1148,7 +1148,7 @@ class TestP4RTL3(object):
 
         # Verify that P4RT key to OID count is same as the original count.
         status, fvs = key_to_oid_helper.get_db_info()
-        assert status == True
+        assert status == False
         assert len(fvs) == len(original_key_oid_info)
 
     def test_PruneNextHopOnWarmBoot(self, dvs, testlog):
@@ -1386,7 +1386,7 @@ class TestP4RTL3(object):
 
         # Verify that P4RT key to OID count is same as the original count.
         status, fvs = key_to_oid_helper.get_db_info()
-        assert status == True
+        assert status == False
         assert len(fvs) == len(original_key_oid_info)
 
     def test_CreateWcmpMemberForOperUpWatchportOnly(self, dvs, testlog):
@@ -1620,7 +1620,7 @@ class TestP4RTL3(object):
 
         # Verify that P4RT key to OID count is same as the original count.
         status, fvs = key_to_oid_helper.get_db_info()
-        assert status == True
+        assert status == False
         assert len(fvs) == len(original_key_oid_info)
 
     def test_RemovePrunedWcmpGroupMember(self, dvs, testlog):
@@ -1841,5 +1841,5 @@ class TestP4RTL3(object):
 
         # Verify that P4RT key to OID count is same as the original count.
         status, fvs = key_to_oid_helper.get_db_info()
-        assert status == True
+        assert status == False
         assert len(fvs) == len(original_key_oid_info)

--- a/tests/p4rt/test_p4rt_acl.py
+++ b/tests/p4rt/test_p4rt_acl.py
@@ -257,8 +257,17 @@ class TestP4RTAcl(object):
         assert status == True
         util.verify_attr(fvs, attr_list)
 
+        asic_udf_matches = util.get_keys(
+            self._p4rt_udf_match_obj.asic_db, self._p4rt_udf_match_obj.ASIC_DB_TBL_NAME
+        )
+
         # query ASIC database for default UDF wildcard match
-        udf_match_asic_db_key = original_asic_udf_matches[0]
+        udf_match_asic_db_keys = [
+            key for key in asic_udf_matches if key not in original_asic_udf_matches
+        ]
+
+        assert len(udf_match_asic_db_keys) == 1
+        udf_match_asic_db_key = udf_match_asic_db_keys[0]
 
         (status, fvs) = util.get_key(
             self._p4rt_udf_match_obj.asic_db,

--- a/tests/test_buffer_dynamic.py
+++ b/tests/test_buffer_dynamic.py
@@ -11,7 +11,6 @@ def dynamic_buffer(dvs):
     yield
     buffer_model.disable_dynamic_buffer(dvs.get_config_db(), dvs.runcmd)
 
-
 @pytest.mark.usefixtures("dynamic_buffer")
 class TestBufferMgrDyn(object):
     DEFAULT_POLLING_CONFIG = PollingConfig(polling_interval=0.01, timeout=60, strict=True)
@@ -129,16 +128,18 @@ class TestBufferMgrDyn(object):
         if fvs.get('dynamic_th'):
             sai_threshold_value = fvs['dynamic_th']
             sai_threshold_mode = 'SAI_BUFFER_PROFILE_THRESHOLD_MODE_DYNAMIC'
+            sai_threshold_name = 'SAI_BUFFER_PROFILE_ATTR_SHARED_DYNAMIC_TH'
         else:
             sai_threshold_value = fvs['static_th']
             sai_threshold_mode = 'SAI_BUFFER_PROFILE_THRESHOLD_MODE_STATIC'
+            sai_threshold_name = 'SAI_BUFFER_PROFILE_ATTR_SHARED_STATIC_TH'
         self.asic_db.wait_for_field_match("ASIC_STATE:SAI_OBJECT_TYPE_BUFFER_PROFILE", self.newProfileInAsicDb,
                                              {'SAI_BUFFER_PROFILE_ATTR_XON_TH': fvs['xon'],
                                               'SAI_BUFFER_PROFILE_ATTR_XOFF_TH': fvs['xoff'],
                                               'SAI_BUFFER_PROFILE_ATTR_RESERVED_BUFFER_SIZE': fvs['size'],
                                               'SAI_BUFFER_PROFILE_ATTR_POOL_ID': self.ingress_lossless_pool_oid,
                                               'SAI_BUFFER_PROFILE_ATTR_THRESHOLD_MODE': sai_threshold_mode,
-                                              'SAI_BUFFER_PROFILE_ATTR_SHARED_DYNAMIC_TH': sai_threshold_value},
+                                              sai_threshold_name: sai_threshold_value},
                                           self.DEFAULT_POLLING_CONFIG)
 
     def make_lossless_profile_name(self, speed, cable_length, mtu = None, dynamic_th = None):

--- a/tests/test_storm_control.py
+++ b/tests/test_storm_control.py
@@ -1,0 +1,316 @@
+from swsscommon import swsscommon
+import os
+import sys
+import time
+import json
+from distutils.version import StrictVersion
+import pytest
+
+class TestStormControl(object):
+    def setup_db(self,dvs):
+        self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)
+        self.adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
+        self.cdb = swsscommon.DBConnector(4, dvs.redis_sock, 0)
+        self.sdb = swsscommon.DBConnector(6, dvs.redis_sock, 0)
+        dvs.runcmd(['sh', '-c', "echo 0 > /var/log/syslog"])
+
+    def create_port_channel(self, dvs, lag_name):
+        dvs.runcmd("config portchannel add " + lag_name)
+        time.sleep(1)
+
+    def delete_port_channel(self, dvs, lag_name):
+        dvs.runcmd("config portchannel del " + lag_name)
+        time.sleep(1)
+
+    def add_port_channel_member(self, dvs, lag_name, member):
+        dvs.runcmd("config portchannel member add "+ lag_name + " "+ member)
+        time.sleep(1)
+
+    def remove_port_channel_member(self, dvs, lag_name, member):
+        dvs.runcmd("config portchannel member del "+ lag_name + " "+ member)
+        time.sleep(1)
+
+    def create_vlan(self, dvs, vlan):
+        dvs.runcmd("config vlan add " + vlan)
+        time.sleep(1)
+
+    def delete_vlan(self, dvs, vlan):
+        dvs.runcmd("config vlan del " + vlan)
+        time.sleep(1)
+
+    def add_vlan_member(self, dvs, vlan, interface):
+        dvs.runcmd("config vlan member add " + vlan + " " + interface)
+        time.sleep(1)
+
+    def remove_vlan_member(self, dvs, vlan, interface):
+        dvs.runcmd("config vlan member del " + vlan + " " + interface)
+        time.sleep(1)
+
+    def add_storm_session(self, if_name, storm_type, kbps_value):
+        tbl = swsscommon.Table(self.cdb, "PORT_STORM_CONTROL")
+        fvs = swsscommon.FieldValuePairs([("kbps", str(kbps_value))])
+        key = if_name + "|" + storm_type
+        tbl.set(key,fvs)
+        time.sleep(1)
+
+    def delete_storm_session(self, if_name, storm_type):
+        tbl = swsscommon.Table(self.cdb, "PORT_STORM_CONTROL")
+        key = if_name + "|" + storm_type
+        tbl._del(key)
+        time.sleep(1)
+
+    def test_bcast_storm(self,dvs,testlog):
+        self.setup_db(dvs)
+
+        if_name = "Ethernet0"
+        storm_type = "broadcast"
+        #User input is Kbps
+        #Orchagent converts the value to CIR as below and programs the ASIC DB
+        #kbps_value * 1000 / 8
+        kbps_value = 1000000
+        self.add_storm_control_on_interface(dvs,if_name,storm_type,kbps_value)
+        self.del_storm_control(dvs,if_name,storm_type)
+
+    def del_storm_control(self, dvs, if_name, storm_type):
+        self.setup_db(dvs)
+        port_oid = dvs.asicdb.portnamemap[if_name]
+        atbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_PORT")
+        status, fvs = atbl.get(dvs.asicdb.portnamemap[if_name])
+        assert status == True
+
+        storm_type_port_attr = self.get_port_attr_for_storm_type(storm_type)
+        
+        policer_oid = 0
+        for fv in fvs:
+            if fv[0] == storm_type_port_attr:
+                policer_oid = fv[1]
+
+        self.delete_storm_session(if_name, storm_type)
+        tbl = swsscommon.Table(self.cdb, "PORT_STORM_CONTROL")
+        (status,fvs) = tbl.get(if_name+"|"+storm_type)
+        assert status == False
+
+        atbl = swsscommon.Table(self.adb,"ASIC_STATE:SAI_OBJECT_TYPE_PORT")
+        status, fvs = atbl.get(dvs.asicdb.portnamemap[if_name])
+        assert status == True
+
+        for fv in fvs:
+            if fv[0] == storm_type_port_attr:
+                assert fv[1] == "oid:0x0"
+
+        if policer_oid != 0:
+            atbl = swsscommon.Table(self.adb,"ASIC_STATE:SAI_OBJECT_TYPE_POLICER")
+            status, fvs = atbl.get(policer_oid)
+            assert status == False
+
+    def test_uucast_storm(self,dvs,testlog):
+        self.setup_db(dvs)
+
+        if_name = "Ethernet0"
+        storm_type = "unknown-unicast"
+        #User input is Kbps
+        #Orchagent converts the value to CIR as below and programs the ASIC DB
+        #kbps_value * 1000 / 8
+        kbps_value = 1000000
+
+        self.add_storm_control_on_interface(dvs,if_name,storm_type,kbps_value)
+        self.del_storm_control(dvs,if_name,storm_type)
+
+    def test_umcast_storm(self,dvs,testlog):
+        self.setup_db(dvs)
+
+        if_name = "Ethernet0"
+        storm_type = "unknown-multicast"
+        #User input is Kbps
+        #Orchagent converts the value to CIR as below and programs the ASIC DB
+        #kbps_value * 1000 / 8
+        kbps_value = 1000000
+
+        self.add_storm_control_on_interface(dvs,if_name,storm_type,kbps_value)
+        self.del_storm_control(dvs,if_name,storm_type)
+
+    def get_port_attr_for_storm_type(self,storm_type):
+        port_attr = ""
+        if storm_type == "broadcast":
+            port_attr = "SAI_PORT_ATTR_BROADCAST_STORM_CONTROL_POLICER_ID"
+        elif storm_type == "unknown-unicast":
+            port_attr = "SAI_PORT_ATTR_FLOOD_STORM_CONTROL_POLICER_ID"
+        elif storm_type == "unknown-multicast":
+            port_attr = "SAI_PORT_ATTR_MULTICAST_STORM_CONTROL_POLICER_ID"
+
+        return port_attr
+
+    def check_storm_control_on_interface(self,dvs,if_name,storm_type,kbps_value):
+        print ("interface {} storm_type {} kbps {}".format(if_name,storm_type, kbps_value))
+        tbl = swsscommon.Table(self.cdb,"PORT_STORM_CONTROL")
+        (status,fvs) = tbl.get(if_name+"|"+storm_type)
+
+        assert status == True
+        assert len(fvs) > 0
+
+        port_oid = dvs.asicdb.portnamemap[if_name]
+
+        atbl = swsscommon.Table(self.adb,"ASIC_STATE:SAI_OBJECT_TYPE_PORT")
+        status, fvs = atbl.get(dvs.asicdb.portnamemap[if_name])
+        assert status == True
+
+        policer_oid = 0
+
+        storm_type_port_attr = self.get_port_attr_for_storm_type(storm_type)
+
+        for fv in fvs:
+            if fv[0] == storm_type_port_attr:
+                assert fv[1] != "oid:0x0"
+                policer_oid = fv[1]
+
+        if policer_oid != 0:
+            atbl = swsscommon.Table(self.adb,"ASIC_STATE:SAI_OBJECT_TYPE_POLICER")
+            status, fvs = atbl.get(policer_oid)
+            assert status == True
+
+        bps = 0
+
+        for fv in fvs:
+            if fv[0] == "SAI_POLICER_ATTR_CIR":
+                bps = fv[1]
+
+        #Retrieved value of bps from ASIC_DB is converted back to user input kbps
+        kbps = int(int(bps) / int(1000) * 8)
+        print ("Kbps value {}".format(kbps))
+
+        assert str(kbps) == str(kbps_value)
+
+
+    def add_storm_control_on_interface(self,dvs,if_name,storm_type,kbps_value):
+        print ("interface {} storm_type {} kbps {}".format(if_name,storm_type,kbps_value))
+        self.add_storm_session(if_name, storm_type, kbps_value)
+        self.check_storm_control_on_interface(dvs,if_name,storm_type,kbps_value)
+
+    def test_add_storm_all_interfaces(self,dvs,testlog):
+        self.setup_db(dvs)
+
+        tbl = swsscommon.Table(self.cdb,"PORT")
+        for key in tbl.getKeys():
+            self.add_storm_control_on_interface(dvs,key,"broadcast",1000000)
+            self.add_storm_control_on_interface(dvs,key,"unknown-unicast",2000000)
+            self.add_storm_control_on_interface(dvs,key,"unknown-multicast",3000000)
+            self.del_storm_control(dvs,key,"broadcast")
+            self.del_storm_control(dvs,key,"unknown-unicast")
+            self.del_storm_control(dvs,key,"unknown-multicast")
+
+    def test_warm_restart_all_interfaces(self,dvs,testlog):
+        self.setup_db(dvs)
+
+        tbl = swsscommon.Table(self.cdb,"PORT")
+        for key in tbl.getKeys():
+            self.add_storm_control_on_interface(dvs,key,"broadcast",1000000)
+            self.add_storm_control_on_interface(dvs,key,"unknown-unicast",2000000)
+            self.add_storm_control_on_interface(dvs,key,"unknown-multicast",3000000)
+        #dvs.runcmd("config save -y")
+        # enable warm restart
+        dvs.warm_restart_swss("true")
+
+        # freeze orchagent for warm restart
+        (exitcode, result) = dvs.runcmd("/usr/bin/orchagent_restart_check")
+        assert result == "RESTARTCHECK succeeded\n"
+        time.sleep(2)
+
+        dvs.stop_swss()
+        time.sleep(10)
+        dvs.start_swss()
+        time.sleep(10)
+
+        for key in tbl.getKeys():
+            self.check_storm_control_on_interface(dvs,key,"broadcast",1000000)
+            self.check_storm_control_on_interface(dvs,key,"unknown-unicast",2000000)
+            self.check_storm_control_on_interface(dvs,key,"unknown-multicast",3000000)
+            self.del_storm_control(dvs,key,"broadcast")
+            self.del_storm_control(dvs,key,"unknown-unicast")
+            self.del_storm_control(dvs,key,"unknown-multicast")
+        # disable warm restart
+        dvs.warm_restart_swss("false")
+
+    def test_add_storm_lag_interface(self,dvs,testlog):
+        self.setup_db(dvs)
+        lag_name = "PortChannel10"
+        member_interface = "Ethernet0"
+        kbps_value = 1000000
+        storm_list = ["broadcast","unknown-unicast","unknown-multicast"]
+        kbps_value_list = [1000000,2000000,3000000]
+
+        #Create LAG interface and add member
+        self.create_port_channel(dvs,lag_name)
+        self.add_port_channel_member(dvs,lag_name,member_interface)
+
+        #click CLI verification
+        #for storm_type in storm_list:
+        #    dvs.runcmd("config interface storm-control add "+lag_name+" "+storm_type+" "+str(kbps_value))
+        #    tbl = swsscommon.Table(self.cdb,"PORT_STORM_CONTROL")
+        #    (status,fvs) = tbl.get(lag_name+"|"+storm_type)
+        #    assert status == False
+        #    assert len(fvs) == 0
+
+        #Orchagent verification
+        storm_list_db = ["broadcast","unknown-unicast","unknown-multicast"]
+        for storm_type,kbps_value in zip(storm_list_db,kbps_value_list):
+            #Cleanup syslog
+            dvs.runcmd(['sh', '-c', "echo 0 > /var/log/syslog"])
+            time.sleep(1)
+            print ("storm type: {} kbps value: {}".format(storm_type,kbps_value))
+            #Add storm entry to config DB directly
+            self.add_storm_session(lag_name,storm_type,kbps_value)
+            tbl = swsscommon.Table(self.cdb,"PORT_STORM_CONTROL")
+            (status,fvs) = tbl.get(lag_name+"|"+storm_type)
+            assert status == True
+            assert len(fvs) > 0
+            time.sleep(1)
+            #grep for error message in syslog
+            (exitcode,num) = dvs.runcmd(['sh', '-c', 'cat /var/log/syslog | grep -i "handlePortStormControlTable: {}: Unsupported / Invalid interface PortChannel10"'.format(storm_type)])
+            time.sleep(1)
+            assert exitcode == 0
+            self.delete_storm_session(lag_name, storm_type)
+        self.remove_port_channel_member(dvs,lag_name,member_interface)
+        self.delete_port_channel(dvs,lag_name)
+
+    def test_add_storm_vlan_interface(self,dvs,testlog):
+        self.setup_db(dvs)
+        vlan_id = 99
+        member_interface = "Ethernet4"
+        kbps_value = 1000000
+        storm_list = ["broadcast","unknown-unicast","unknown-multicast"]
+        kbps_value_list = [1000000,2000000,3000000]
+        vlan_name = "Vlan"+str(vlan_id)
+
+        #Create VLAN interface and add member
+        self.create_vlan(dvs,str(vlan_id))
+        self.add_vlan_member(dvs,str(vlan_id),member_interface)
+
+        #click CLI verification 
+        #for storm_type in storm_list:
+        #    dvs.runcmd("config interface storm-control add Vlan"+str(vlan_id)+" "+storm_type+" "+str(kbps_value))
+        #    tbl = swsscommon.Table(self.cdb,"PORT_STORM_CONTROL")
+        #    (status,fvs) = tbl.get("Vlan"+str(vlan_id)+"|"+storm_type)
+        #    assert status == False
+        #    assert len(fvs) == 0
+
+        #Orchagent verification
+        storm_list_db = ["broadcast","unknown-unicast","unknown-multicast"]
+        for storm_type,kbps_value in zip(storm_list_db,kbps_value_list):
+            #Cleanup syslog
+            dvs.runcmd(['sh', '-c', "echo 0 > /var/log/syslog"])
+            time.sleep(1)
+            print ("storm type: {} kbps value: {}".format(storm_type,kbps_value))
+            #Add storm entry to config DB directly
+            self.add_storm_session(vlan_name,storm_type,kbps_value)
+            tbl = swsscommon.Table(self.cdb,"PORT_STORM_CONTROL")
+            (status,fvs) = tbl.get(vlan_name+"|"+storm_type)
+            assert status == True
+            assert len(fvs) > 0
+            time.sleep(1)
+            #grep for error message in syslog
+            (exitcode,num) = dvs.runcmd(['sh', '-c', 'cat /var/log/syslog | grep -i "handlePortStormControlTable: {}: Unsupported / Invalid interface {}"'.format(storm_type,vlan_name)])
+            time.sleep(1)
+            assert exitcode == 0
+            self.delete_storm_session(vlan_name, storm_type)
+        self.remove_vlan_member(dvs,str(vlan_id),member_interface)
+        self.delete_vlan(dvs,str(vlan_id))


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
1. Support mock test for dynamic buffer manager
2. Fix bugs during mock test implementation
3. Remove vs test cases that can be covered by mock test.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

**Why I did it**

**How I verified it**
Run regression test, mock test, vs test and manual test.

**Details if related**
1. Support mock test for dynamic buffer manager
   - Normal flow: simulate the case that all `CONFIG_DB` table items are ready when the buffer manager starts
   - Sad flow:
     - some `CONFIG_DB` table items are received after the buffer manager starts
     - table items that reference other tables are received first
     - `ingress_lossless_pool` should not be created on receiving `over-subscription-ratio` only
   - `config qos clear` and reclaiming buffer
   - Remove port
2. Adjust buffer manager for mock test:
   - Do not load Lua plugins for mock test.
   - Skip a not-yet-configured buffer pool returned by Lua plugin.
3. Bugs fixed during mock test implementation
   - Do not calculate lossless headroom if the port is not `READY`
   - Do not create `ingress_lossless_pool` without configured from `CONFIG_DB`
   - Remove buffer profile from `m_bufferProfileLookup` if a profile has not been successfully created
   - Remove the port object if there is no PG/queue left on a port
   - Do not exit `doTask` in case failed to handle a notification 
4. Handle port remove/create flow
   - Cache cable length for a port
   - Try reclaiming unused buffer when maximum buffer parameters are received for a port whose state is `ADMIN_DOWN` and `m_bufferCompletelyInitialized` is `true`
5. Handle `config qos clear`
   - If all buffer pools are removed when `m_bufferPoolReady` is true, remove all zero pools and profiles.
   - Reload zero profiles and pools if they have not been loaded when reclaiming buffer 
