### PR TITLE
[portsorch] Expose supported FEC modes to STABE_DB and check whether FEC mode is supported before setting it

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2008,6 +2008,15 @@ void PortsOrch::initPortSupportedFecModes(const std::string& alias, sai_object_i
     supported_fec_modes.fecModes.resize(fec_mode_reverse_map.size());
     getPortSupportedFecModes(alias, port_id, supported_fec_modes);
     m_portSupportedFecModes[port_id] = supported_fec_modes;
+
+    if (supported_fec_modes.unknown)
+    {
+        // Do not expose "supported_fecs" in case fetching FEC modes is not supported by the vendor
+        SWSS_LOG_INFO("No supported_fecs exposed to STATE_DB for port %s since fetching supported FEC modes is not supported by the vendor",
+                      alias.c_str());
+        return;
+    }
+
     vector<FieldValueTuple> v;
     std::string supported_fec_modes_str;
     if (!supported_fec_modes.fecModes.empty())

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1150,18 +1150,21 @@ bool PortsOrch::setPortFec(Port &port, sai_port_fec_mode_t mode)
     if (searchRef != m_portSupportedFecModes.end())
     {
         auto &supportedFecModes = searchRef->second;
-        bool found = false;
-        for (auto supportedFecMode : supportedFecModes)
+        if (!supportedFecModes.empty())
         {
-            if (mode == supportedFecMode)
+            bool found = false;
+            for (auto supportedFecMode : supportedFecModes)
             {
-                found = true;
+                if (mode == supportedFecMode)
+                {
+                    found = true;
+                }
             }
-        }
-        if (!found)
-        {
-            SWSS_LOG_ERROR("Unsupported mode %d on port %" PRIx64, mode, port.m_port_id);
-            return false;
+            if (!found)
+            {
+                SWSS_LOG_ERROR("Unsupported mode %d on port %" PRIx64, mode, port.m_port_id);
+                return false;
+            }
         }
     }
 

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -27,12 +27,7 @@
 #define PG_DROP_STAT_COUNTER_FLEX_COUNTER_GROUP "PG_DROP_STAT_COUNTER"
 
 typedef std::vector<sai_uint32_t> PortSupportedSpeeds;
-typedef struct
-{
-    std::vector<sai_int32_t> fecModes;
-    // unknown is true in case fetching SAI_PORT_ATTR_SUPPORTED_FEC_MODE is not supported by vendor SAI
-    bool unknown;
-} PortSupportedFecModes;
+typedef std::set<std::string> PortSupportedFecModes;
 
 static const map<sai_port_oper_status_t, string> oper_status_strings =
 {

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -28,7 +28,12 @@
 #define PG_DROP_STAT_COUNTER_FLEX_COUNTER_GROUP "PG_DROP_STAT_COUNTER"
 
 typedef std::vector<sai_uint32_t> PortSupportedSpeeds;
-typedef std::vector<sai_int32_t> PortSupportedFecModes;
+typedef struct
+{
+    std::vector<sai_int32_t> fecModes;
+    // unknown is true in case fetching SAI_PORT_ATTR_SUPPORTED_FEC_MODE is not supported by vendor SAI
+    bool unknown;
+} PortSupportedFecModes;
 
 static const map<sai_port_oper_status_t, string> oper_status_strings =
 {

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -28,6 +28,7 @@
 #define PG_DROP_STAT_COUNTER_FLEX_COUNTER_GROUP "PG_DROP_STAT_COUNTER"
 
 typedef std::vector<sai_uint32_t> PortSupportedSpeeds;
+typedef std::vector<sai_int32_t> PortSupportedFecModes;
 
 static const map<sai_port_oper_status_t, string> oper_status_strings =
 {
@@ -210,6 +211,7 @@ private:
     unique_ptr<Table> m_gbcounterTable;
 
     std::map<sai_object_id_t, PortSupportedSpeeds> m_portSupportedSpeeds;
+    std::map<sai_object_id_t, PortSupportedFecModes> m_portSupportedFecModes;
 
     bool m_initDone = false;
     Port m_cpuPort;
@@ -315,6 +317,8 @@ private:
     bool isSpeedSupported(const std::string& alias, sai_object_id_t port_id, sai_uint32_t speed);
     void getPortSupportedSpeeds(const std::string& alias, sai_object_id_t port_id, PortSupportedSpeeds &supported_speeds);
     void initPortSupportedSpeeds(const std::string& alias, sai_object_id_t port_id);
+    void getPortSupportedFecModes(const std::string& alias, sai_object_id_t port_id, PortSupportedFecModes &supported_fecmodes);
+    void initPortSupportedFecModes(const std::string& alias, sai_object_id_t port_id);
     task_process_status setPortSpeed(Port &port, sai_uint32_t speed);
     bool getPortSpeed(sai_object_id_t id, sai_uint32_t &speed);
     bool setGearboxPortsAttr(Port &port, sai_port_attr_t id, void *value);

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -311,7 +311,7 @@ private:
     bool setPortTpid(sai_object_id_t id, sai_uint16_t tpid);
     bool setPortPvid (Port &port, sai_uint32_t pvid);
     bool getPortPvid(Port &port, sai_uint32_t &pvid);
-    bool setPortFec(Port &port, sai_port_fec_mode_t mode);
+    bool setPortFec(Port &port, std::string &mode);
     bool setPortPfcAsym(Port &port, string pfc_asym);
     bool getDestPortId(sai_object_id_t src_port_id, dest_port_type_t port_type, sai_object_id_t &des_port_id);
 

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -92,6 +92,7 @@ namespace portsorch_test
     }
 
     bool testing_fec;
+    bool not_support_fetching_fec;
     vector<sai_port_fec_mode_t> mock_port_fec_modes = {SAI_PORT_FEC_MODE_RS, SAI_PORT_FEC_MODE_FC};
 
     sai_status_t _ut_stub_sai_get_port_attribute(
@@ -102,19 +103,40 @@ namespace portsorch_test
         sai_status_t status;
         if (testing_fec && attr_count == 1 && attr_list[0].id == SAI_PORT_ATTR_SUPPORTED_FEC_MODE)
         {
-            uint32_t i;
-            for (i = 0; i < attr_list[0].value.s32list.count && i < mock_port_fec_modes.size(); i++)
+            if (not_support_fetching_fec)
             {
-                attr_list[0].value.s32list.list[i] = mock_port_fec_modes[i];
+                status = SAI_STATUS_NOT_IMPLEMENTED;
             }
-            attr_list[0].value.s32list.count = i;
-            status = SAI_STATUS_SUCCESS;
+            else
+            {
+                uint32_t i;
+                for (i = 0; i < attr_list[0].value.s32list.count && i < mock_port_fec_modes.size(); i++)
+                {
+                    attr_list[0].value.s32list.list[i] = mock_port_fec_modes[i];
+                }
+                attr_list[0].value.s32list.count = i;
+                status = SAI_STATUS_SUCCESS;
+            }
         }
         else
         {
             status = pold_sai_port_api->get_port_attribute(port_id, attr_count, attr_list);
         }
         return status;
+    }
+
+    uint32_t _sai_set_port_fec_count;
+    int32_t _sai_port_fec_mode;
+    sai_status_t _ut_stub_sai_set_port_attribute(
+        _In_ sai_object_id_t port_id,
+        _In_ const sai_attribute_t *attr)
+    {
+        if (testing_fec && attr[0].id == SAI_PORT_ATTR_FEC_MODE)
+        {
+            _sai_set_port_fec_count++;
+            _sai_port_fec_mode = attr[0].value.s32;
+        }
+        return pold_sai_port_api->set_port_attribute(port_id, attr);
     }
 
     void _hook_sai_buffer_and_queue_api()
@@ -134,6 +156,7 @@ namespace portsorch_test
         ut_sai_port_api = *sai_port_api;
         pold_sai_port_api = sai_port_api;
         ut_sai_port_api.get_port_attribute = _ut_stub_sai_get_port_attribute;
+        ut_sai_port_api.set_port_attribute = _ut_stub_sai_set_port_attribute;
         sai_port_api = &ut_sai_port_api;
     }
 
@@ -313,6 +336,7 @@ namespace portsorch_test
         std::deque<KeyOpFieldsValuesTuple> entries;
 
         testing_fec = true;
+        not_support_fetching_fec = false;
         // Get SAI default ports to populate DB
         auto ports = ut_helper::getInitialSaiPorts();
 
@@ -331,6 +355,8 @@ namespace portsorch_test
         //  create ports
         static_cast<Orch *>(gPortsOrch)->doTask();
 
+        uint32_t current_sai_api_call_count = _sai_set_port_fec_count;
+
         entries.push_back({"Ethernet0", "SET",
                            {
                                {"fec", "rs"}
@@ -339,6 +365,9 @@ namespace portsorch_test
         consumer->addToSync(entries);
         static_cast<Orch *>(gPortsOrch)->doTask();
         entries.clear();
+
+        ASSERT_EQ(_sai_set_port_fec_count, ++current_sai_api_call_count);
+        ASSERT_EQ(_sai_port_fec_mode, SAI_PORT_FEC_MODE_RS);
 
         vector<string> ts;
 
@@ -353,9 +382,61 @@ namespace portsorch_test
         consumer->addToSync(entries);
         static_cast<Orch *>(gPortsOrch)->doTask();
 
+        ASSERT_EQ(_sai_set_port_fec_count, current_sai_api_call_count);
+        ASSERT_EQ(_sai_port_fec_mode, SAI_PORT_FEC_MODE_RS);
+
         gPortsOrch->dumpPendingTasks(ts);
         ASSERT_EQ(ts.size(), 1);
         ASSERT_EQ(ts[0], "PORT_TABLE:Ethernet0|SET|fec:none");
+
+        testing_fec = false;
+        _unhook_sai_buffer_and_queue_api();
+    }
+
+    TEST_F(PortsOrchTest, PortNotSupportedFecModes)
+    {
+        _hook_sai_buffer_and_queue_api();
+        Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+        std::deque<KeyOpFieldsValuesTuple> entries;
+
+        testing_fec = true;
+        not_support_fetching_fec = true;
+        // Get SAI default ports to populate DB
+        auto ports = ut_helper::getInitialSaiPorts();
+
+        for (const auto &it : ports)
+        {
+            portTable.set(it.first, it.second);
+        }
+
+        // Set PortConfigDone
+        portTable.set("PortConfigDone", { { "count", to_string(ports.size()) } });
+
+        // refill consumer
+        gPortsOrch->addExistingData(&portTable);
+
+        // Apply configuration :
+        //  create ports
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        uint32_t current_sai_api_call_count = _sai_set_port_fec_count;
+
+        entries.push_back({"Ethernet0", "SET",
+                           {
+                               {"fec", "rs"}
+                           }});
+        auto consumer = dynamic_cast<Consumer *>(gPortsOrch->getExecutor(APP_PORT_TABLE_NAME));
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+        entries.clear();
+
+        ASSERT_EQ(_sai_set_port_fec_count, ++current_sai_api_call_count);
+        ASSERT_EQ(_sai_port_fec_mode, SAI_PORT_FEC_MODE_RS);
+
+        vector<string> ts;
+
+        gPortsOrch->dumpPendingTasks(ts);
+        ASSERT_TRUE(ts.empty());
 
         testing_fec = false;
         _unhook_sai_buffer_and_queue_api();


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Expose supported FEC modes to `STATE_DB.PORT_TABLE|<port>.supported_fecs`.
The orchagent calls `get_port_attribute` to get attribute `SAI_PORT_ATTR_SUPPORTED_FEC_MODE` during initialization and then records it into internal data.
   - By default, the supported FEC modes will be returned by SAI and exposed to `STATE_DB`. Eg. `rs,none` means only `rs` and `none` is supported on the port.
     - The orchagent will check whether the FEC mode is supported on the port before calling the SAI API to set it.
     - The CLI will check whether the FEC mode is in `supported_fecs` before setting FEC mode on a port to the `CONFIG_DB`
   - In case the SAI API does not support any FEC mode on the port, `N/A` will be exposed to `STATE_DB`
     - The orchagent will deny any FEC setting and prints log.
     - The CLI will deny FEC setting.
   - In case the SAI API `get_port_attribute` returns `Not implemented`
     - No check will be performed before setting a FEC mode to SAI on the port.
     - The CLI will check whether the FEC mode is defined before setting it to `CONFIG_DB`.

**Why I did it**
It is not supported to set FEC mode on some platforms. To avoid error, we need to expose the supported FEC list.

**How I verified it**
Manually test and mock test.

**Details if related**
