### PR TITLE
[202205] Enhance orchagent and buffer manager in error handling (Cherry-pick #2414)

### DIFF
--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -393,7 +393,7 @@ ref_resolve_status Orch::resolveFieldRefValue(
             {
                 return ref_resolve_status::not_resolved;
             }
-            else if (ref_type_name.empty() && object_name.empty())
+            else if (object_name.empty())
             {
                 return ref_resolve_status::empty;
             }

--- a/tests/mock_tests/qosorch_ut.cpp
+++ b/tests/mock_tests/qosorch_ut.cpp
@@ -1337,4 +1337,35 @@ namespace qosorch_test
 
         testing_wred_thresholds = false;
     }
+
+    /*
+     * Make sure empty fields won't cause orchagent crash
+     */
+    TEST_F(QosOrchTest, QosOrchTestEmptyField)
+    {
+        // Create a new dscp to tc map
+        std::deque<KeyOpFieldsValuesTuple> entries;
+        entries.push_back({"Ethernet0", "SET",
+                            {
+                                {"dscp_to_tc_map", ""}
+                            }});
+        auto consumer = dynamic_cast<Consumer *>(gQosOrch->getExecutor(CFG_PORT_QOS_MAP_TABLE_NAME));
+        consumer->addToSync(entries);
+        entries.clear();
+
+        entries.push_back({"Ethernet0|3", "SET",
+                           {
+                               {"scheduler", ""}
+                           }});
+        entries.push_back({"Ethernet0|4", "SET",
+                           {
+                               {"wred_profile", ""}
+                           }});
+        consumer = dynamic_cast<Consumer *>(gQosOrch->getExecutor(CFG_QUEUE_TABLE_NAME));
+        consumer->addToSync(entries);
+        entries.clear();
+
+        // Drain DSCP_TO_TC_MAP and PORT_QOS_MAP table
+        static_cast<Orch *>(gQosOrch)->doTask();
+    }
 }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Enhance orchagent and buffer manager
- Buffer manager: do not insert buffer queue into cache if the profile is illegal, which prevents an empty string from being inserted into `APPL_DB` during initialization.
- orchagent: handle the case that a field referencing other objects is an empty string.
  There had been such logic that was broken by a PR last year.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

**Why I did it**
Enhance the error handling logic.
In most cases, a user will not encounter such scenarios in a production environment because it's the front-ends' (eg. CLI) responsibility to identify the wrong configuration and prevent them from being inserted to `CONFIG_DB`.
However, in some cases, like a wrong `config_db.json` composed and copied to the switch, front-ends can not prevent that.

**How I verified it**
Manual and mock tests.

**Details if related**
For the improvement in buffer manager:
- previously, the logic was:
  - declare a reference `portQueue` to `m_portQueueLookup[port][queues]` and then assign `fvValue(i)` to `portQueue.running_profile_name`
  - But `[]` operation on C++ map has a side-effect -- it will insert a new element into the map if there wasn't one. In case the validation check in `checkBufferProfileDirection` failed and there was not one in the map, the `portQueue.running_profile_name` will keep empty. This is not what we want.
  - In case there was an item configured in the map, we should not remove it on failure because we want to prevent the user from being affected by misconfiguration and alert user to correct the error. There is log in `checkBufferProfileDirection`
- Now it is improved in this way:
  - Avoid using reference and initialize `m_portQueueLookup[port][queues]` only if there is a valid egress profile configured