### PR TITLE
Avoid aborting orchagent when setting TUNNEL attributes

### DIFF
--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -959,6 +959,18 @@ task_process_status Orch::handleSaiSetStatus(sai_api_t api, sai_status_t status,
                             sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());
                     abort();
             }
+        case SAI_API_TUNNEL:
+            switch (status)
+            {
+                case SAI_STATUS_ATTR_NOT_SUPPORTED_0:
+                    SWSS_LOG_ERROR("Encountered SAI_STATUS_ATTR_NOT_SUPPORTED_0 in set operation, task failed, SAI API: %s, status: %s",
+                            sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());
+                    return task_failed;
+                default:
+                    SWSS_LOG_ERROR("Encountered failure in set operation, exiting orchagent, SAI API: %s, status: %s",
+                            sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());
+                    abort();
+            }
         default:
             SWSS_LOG_ERROR("Encountered failure in set operation, exiting orchagent, SAI API: %s, status: %s",
                         sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());

--- a/orchagent/tunneldecaporch.cpp
+++ b/orchagent/tunneldecaporch.cpp
@@ -144,7 +144,9 @@ void TunnelDecapOrch::doTask(Consumer& consumer)
                     }
                     if (exists)
                     {
-                        setTunnelAttribute(fvField(i), ecn_mode, tunnel_id);
+                        SWSS_LOG_NOTICE("Skip setting ecn_mode since the SAI attribute SAI_TUNNEL_ATTR_DECAP_ECN_MODE is create only");
+                        valid = false;
+                        break;
                     }
                 }
                 else if (fvField(i) == "encap_ecn_mode")
@@ -158,7 +160,9 @@ void TunnelDecapOrch::doTask(Consumer& consumer)
                     }
                     if (exists)
                     {
-                        setTunnelAttribute(fvField(i), encap_ecn_mode, tunnel_id);
+                        SWSS_LOG_NOTICE("Skip setting encap_ecn_mode since the SAI attribute SAI_TUNNEL_ATTR_ENCAP_ECN_MODE is create only");
+                        valid = false;
+                        break;
                     }
                 }
                 else if (fvField(i) == "ttl_mode")
@@ -581,30 +585,6 @@ bool TunnelDecapOrch::setTunnelAttribute(string field, string value, sai_object_
 {
 
     sai_attribute_t attr;
-
-    if (field == "ecn_mode")
-    {
-        // decap ecn mode (copy from outer/standard)
-        attr.id = SAI_TUNNEL_ATTR_DECAP_ECN_MODE;
-        if (value == "copy_from_outer")
-        {
-            attr.value.s32 = SAI_TUNNEL_DECAP_ECN_MODE_COPY_FROM_OUTER;
-        }
-        else if (value == "standard")
-        {
-            attr.value.s32 = SAI_TUNNEL_DECAP_ECN_MODE_STANDARD;
-        }
-    }
-
-    if (field == "encap_ecn_mode")
-    {
-        // encap ecn mode (only standard is supported)
-        attr.id = SAI_TUNNEL_ATTR_ENCAP_ECN_MODE;
-        if (value == "standard")
-        {
-            attr.value.s32 = SAI_TUNNEL_ENCAP_ECN_MODE_STANDARD;
-        }
-    }
 
     if (field == "ttl_mode")
     {


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Avoid aborting orchagent when setting TUNNEL attributes

1. Do not abort orchagent if vendor SAI returns SAI_STATUS_ATTR_NOT_SUPPORTED_0
2. Skip setting create-only attributes

Signed-off-by: Stephen Sun <stephens@nvidia.com>

**Why I did it**

**How I verified it**

**Details if related**
