### PR TITLE
[QoS] Enhance the logic to check maximum headroom exceeding to cover corner scenarios

### DIFF
--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -1497,7 +1497,7 @@ task_process_status BufferMgrDynamic::refreshPgsForPort(const string &port, cons
 
         // Calculate whether accumulative headroom size exceeds the maximum value
         // Abort if it does
-        if (!isHeadroomResourceValid(port, m_bufferProfileLookup[newProfile], exactly_matched_key))
+        if (!isHeadroomResourceValid(port, m_bufferProfileLookup[newProfile], key))
         {
             SWSS_LOG_ERROR("Update speed (%s) and cable length (%s) for port %s failed, accumulative headroom size exceeds the limit",
                            speed.c_str(), cable_length.c_str(), port.c_str());

--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -1051,10 +1051,10 @@ bool BufferMgrDynamic::isHeadroomResourceValid(const string &port, const buffer_
     // profile: the profile referenced by the new_pg (if provided) or all PGs
     // new_pg: which pg is newly added?
 
-    if (!profile.lossless)
+    if (!profile.lossless && new_pg.empty())
     {
-        SWSS_LOG_INFO("No need to check headroom for lossy PG port %s profile %s size %s pg %s",
-                  port.c_str(), profile.name.c_str(), profile.size.c_str(), new_pg.c_str());
+        SWSS_LOG_INFO("No need to check headroom for lossy PG port %s profile %s size %s without a PG specified",
+                  port.c_str(), profile.name.c_str(), profile.size.c_str());
         return true;
     }
 
@@ -3005,6 +3005,11 @@ task_process_status BufferMgrDynamic::handleSingleBufferPgEntry(const string &ke
                     bufferPg.dynamic_calculated = profileRef.dynamic_calculated;
                     bufferPg.configured_profile_name = profileName;
                     bufferPg.lossless = profileRef.lossless;
+                    if (!profileRef.lossless && !isHeadroomResourceValid(port, profileRef, key))
+                    {
+                        SWSS_LOG_ERROR("Unable to configure lossy PG %s, accumulative headroom size exceeds the limit", key.c_str());
+                        return task_process_status::task_failed;
+                    }
                 }
                 bufferPg.static_configured = true;
                 bufferPg.configured_profile_name = profileName;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Enhance the logic to check maximum headroom exceeding to cover corner scenarios

Currently, the logic to check the maximum headroom exceeding works well when a user changes any buffer configuration in the dynamic buffer model, preventing all problematic configurations from being applied to the ASIC.
However, it can fail when a problematic configuration is `config_db.json` and `config reload` is executed. To cover this scenario, the following actions need to be done:

1. Take the pending PG keys and buffer profiles into account when calculating the maximum headroom
    - Existing buffer PGs and buffer profiles can be in the pending queue since there are a large number of notifications needed to be handled during system initialization, which takes time.
2. Take the lossy PG into account when calculating the maximum headroom.
    - Non-default lossy PG can be added by the user in `config_db.json`
3. Pass the PG to the Lua plugin when refreshing PGs for a port

Signed-off-by: Stephen Sun <stephens@nvidia.com>

**Why I did it**

Cover corner scenarios.

**How I verified it**

Manual test, vs test, regression test (dynamic buffer)

**Details if related**
