### PR TITLE
[Buffer orch] Fix maximum headroom check failure in cold reboot

### DIFF
--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -642,6 +642,20 @@ task_process_status handleSaiSetStatus(sai_api_t api, sai_status_t status, void 
                     break;
             }
             break;
+        case SAI_API_BUFFER:
+            switch (status)
+            {
+                case SAI_STATUS_INSUFFICIENT_RESOURCES:
+                    SWSS_LOG_ERROR("Encountered SAI_STATUS_INSUFFICIENT_RESOURCES in set operation, task failed, SAI API: %s, status: %s",
+                                   sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());
+                    return task_failed;
+                default:
+                    SWSS_LOG_ERROR("Encountered failure in set operation, exiting orchagent, SAI API: %s, status: %s",
+                            sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());
+                    handleSaiFailure(true);
+                    break;
+            }
+            break;
         default:
             SWSS_LOG_ERROR("Encountered failure in set operation, exiting orchagent, SAI API: %s, status: %s",
                         sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Fix maximum headroom check failure in the cold reboot.
The accumulative headroom on a port is compared with the maximum headroom supported on the port whenever a buffer priority group is created/updated in the dynamic buffer model which depends on the maximum headroom being exposed to the STATE_DB during orchagent initialization.
However, in the cold reboot, orchagent starts slow which prevents the threshold from being exposed on time. In this case, the buffer manager is not able to perform the headroom check and the buffer orchagent should handle the possible failure from SAI in case the accumulative headroom exceeds the threshold.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

**Why I did it**

To fix the issue.

**How I verified it**

Manually/regression test.

**Details if related**
