### PR TITLE
Fix flow counter out-of-order issue by notifying counter operations using SelectableChannel

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -22,10 +22,6 @@ extern sai_object_id_t gSwitchId;
 extern string gMySwitchType;
 extern string gMyHostName;
 extern string gMyAsicName;
-extern bool gTraditionalFlexCounter;
-
-#define BUFFER_POOL_WATERMARK_FLEX_STAT_COUNTER_POLL_MSECS  "60000"
-
 
 static const vector<sai_buffer_pool_stat_t> bufferPoolWatermarkStatIds =
 {
@@ -53,9 +49,6 @@ std::map<string, std::map<size_t, string>> queue_port_flags;
 
 BufferOrch::BufferOrch(DBConnector *applDb, DBConnector *confDb, DBConnector *stateDb, vector<string> &tableNames) :
     Orch(applDb, tableNames),
-    m_flexCounterDb(new DBConnector("FLEX_COUNTER_DB", 0)),
-    m_flexCounterTable(new ProducerTable(m_flexCounterDb.get(), FLEX_COUNTER_TABLE)),
-    m_flexCounterGroupTable(new ProducerTable(m_flexCounterDb.get(), FLEX_COUNTER_GROUP_TABLE)),
     m_countersDb(new DBConnector("COUNTERS_DB", 0)),
     m_stateBufferMaximumValueTable(stateDb, STATE_BUFFER_MAXIMUM_VALUE_TABLE)
 {
@@ -242,30 +235,11 @@ void BufferOrch::initFlexCounterGroupTable(void)
         SWSS_LOG_ERROR("Buffer pool watermark lua script and/or flex counter group not set successfully. Runtime error: %s", e.what());
     }
 
-    if (gTraditionalFlexCounter)
-    {
-        vector<FieldValueTuple> fvTuples;
-        fvTuples.emplace_back(BUFFER_POOL_PLUGIN_FIELD, bufferPoolWmSha);
-        fvTuples.emplace_back(POLL_INTERVAL_FIELD, BUFFER_POOL_WATERMARK_FLEX_STAT_COUNTER_POLL_MSECS);
-
-        m_flexCounterGroupTable->set(BUFFER_POOL_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP, fvTuples);
-    }
-    else
-    {
-        sai_redis_flex_counter_group_parameter_t flexCounterGroupParam;
-        sai_attribute_t attr;
-
-        flexCounterGroupParam.counter_group_name = BUFFER_POOL_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP;
-        flexCounterGroupParam.poll_interval = BUFFER_POOL_WATERMARK_FLEX_STAT_COUNTER_POLL_MSECS;
-        flexCounterGroupParam.plugin_name = BUFFER_POOL_PLUGIN_FIELD;
-        flexCounterGroupParam.plugins = bufferPoolWmSha.c_str();
-        flexCounterGroupParam.stats_mode = nullptr;
-        flexCounterGroupParam.operation = nullptr;
-
-        attr.id = SAI_REDIS_SWITCH_ATTR_FLEX_COUNTER_GROUP;
-        attr.value.ptr = (void*)&flexCounterGroupParam;
-        sai_switch_api->set_switch_attribute(gSwitchId, &attr);
-    }
+    setFlexCounterGroupParameter(BUFFER_POOL_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP,
+                                 BUFFER_POOL_WATERMARK_FLEX_STAT_COUNTER_POLL_MSECS,
+                                 "", // do not touch stats_mode
+                                 BUFFER_POOL_PLUGIN_FIELD,
+                                 bufferPoolWmSha);
 }
 
 bool BufferOrch::isPortReady(const std::string& port_name) const
@@ -296,21 +270,7 @@ void BufferOrch::clearBufferPoolWatermarkCounterIdList(const sai_object_id_t obj
     if (m_isBufferPoolWatermarkCounterIdListGenerated)
     {
         string key = BUFFER_POOL_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP ":" + sai_serialize_object_id(object_id);
-        if (gTraditionalFlexCounter)
-        {
-            m_flexCounterTable->del(key);
-        }
-        else
-        {
-            sai_attribute_t attr;
-            sai_redis_flex_counter_parameter_t counterParam = {nullptr, nullptr, nullptr, nullptr};
-            counterParam.counter_key = key.c_str();
-            attr.value.ptr = &counterParam;
-
-            attr.id = SAI_REDIS_SWITCH_ATTR_FLEX_COUNTER;
-
-            sai_switch_api->set_switch_attribute(gSwitchId, &attr);
-        }
+        stopFlexCounterPolling(gSwitchId, key);
     }
 }
 
@@ -361,93 +321,32 @@ void BufferOrch::generateBufferPoolWatermarkCounterIdList(void)
 
     if (!noWmClrCapability)
     {
-        if (gTraditionalFlexCounter)
-        {
-            vector<FieldValueTuple> fvs;
-
-            fvs.emplace_back(STATS_MODE_FIELD, STATS_MODE_READ_AND_CLEAR);
-            m_flexCounterGroupTable->set(BUFFER_POOL_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP, fvs);
-        }
-        else
-        {
-            sai_redis_flex_counter_group_parameter_t flexCounterGroupParam;
-            sai_attribute_t attr;
-
-            flexCounterGroupParam.counter_group_name = BUFFER_POOL_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP;
-            flexCounterGroupParam.poll_interval = nullptr;
-            flexCounterGroupParam.plugins = nullptr;
-            flexCounterGroupParam.stats_mode = STATS_MODE_READ_AND_CLEAR;
-            flexCounterGroupParam.operation = nullptr;
-
-            attr.id = SAI_REDIS_SWITCH_ATTR_FLEX_COUNTER_GROUP;
-            attr.value.ptr = (void*)&flexCounterGroupParam;
-            sai_switch_api->set_switch_attribute(gSwitchId, &attr);
-        }
+        setFlexCounterGroupStatsMode(BUFFER_POOL_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP,
+                                     STATS_MODE_READ_AND_CLEAR);
     }
 
     // Push buffer pool watermark COUNTER_ID_LIST to FLEX_COUNTER_TABLE on a per buffer pool basis
-    if (gTraditionalFlexCounter)
+    string stats_mode;
+
+    bitMask = 1;
+
+    for (const auto &it : *(m_buffer_type_maps[APP_BUFFER_POOL_TABLE_NAME]))
     {
-        vector<FieldValueTuple> fvTuples;
-        fvTuples.emplace_back(BUFFER_POOL_COUNTER_ID_LIST, statList);
-        bitMask = 1;
-        for (const auto &it : *(m_buffer_type_maps[APP_BUFFER_POOL_TABLE_NAME]))
+        string key = BUFFER_POOL_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP ":" + sai_serialize_object_id(it.second.m_saiObjectId);
+
+        stats_mode = "";
+
+        if (noWmClrCapability)
         {
-            string key = BUFFER_POOL_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP ":" + sai_serialize_object_id(it.second.m_saiObjectId);
-
-            if (noWmClrCapability)
+            if (noWmClrCapability & bitMask)
             {
-                string stats_mode = STATS_MODE_READ_AND_CLEAR;
-                if (noWmClrCapability & bitMask)
-                {
-                    stats_mode = STATS_MODE_READ;
-                }
-                fvTuples.emplace_back(STATS_MODE_FIELD, stats_mode);
+                stats_mode = STATS_MODE_READ;
+            }
 
-                m_flexCounterTable->set(key, fvTuples);
-                fvTuples.pop_back();
-                bitMask <<= 1;
-            }
-            else
-            {
-                m_flexCounterTable->set(key, fvTuples);
-            }
+            bitMask <<= 1;
         }
-    }
-    else
-    {
-        sai_attribute_t attr;
-        sai_redis_flex_counter_parameter_t counterParam = {nullptr, nullptr, nullptr, nullptr};
 
-        counterParam.counter_ids = statList.c_str();
-        counterParam.counter_field_name = BUFFER_POOL_COUNTER_ID_LIST;
-
-        attr.id = SAI_REDIS_SWITCH_ATTR_FLEX_COUNTER;
-        attr.value.ptr = &counterParam;
-
-        bitMask = 1;
-
-        for (const auto &it : *(m_buffer_type_maps[APP_BUFFER_POOL_TABLE_NAME]))
-        {
-            string key = BUFFER_POOL_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP ":" + sai_serialize_object_id(it.second.m_saiObjectId);
-
-            counterParam.counter_key = key.c_str();
-            if (noWmClrCapability)
-            {
-                if (noWmClrCapability & bitMask)
-                {
-                    counterParam.stats_mode = STATS_MODE_READ;
-                }
-                else
-                {
-                    counterParam.stats_mode = STATS_MODE_READ_AND_CLEAR;
-                }
-
-                bitMask <<= 1;
-            }
-
-            sai_switch_api->set_switch_attribute(gSwitchId, &attr);
-        }
+        startFlexCounterPolling(gSwitchId, key, statList, BUFFER_POOL_COUNTER_ID_LIST, stats_mode);
     }
 
     m_isBufferPoolWatermarkCounterIdListGenerated = true;

--- a/orchagent/bufferorch.h
+++ b/orchagent/bufferorch.h
@@ -9,6 +9,7 @@
 #include "redisapi.h"
 
 #define BUFFER_POOL_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP "BUFFER_POOL_WATERMARK_STAT_COUNTER"
+#define BUFFER_POOL_WATERMARK_FLEX_STAT_COUNTER_POLL_MSECS  "60000"
 
 const string buffer_size_field_name         = "size";
 const string buffer_pool_type_field_name    = "type";
@@ -62,10 +63,6 @@ private:
     buffer_table_handler_map m_bufferHandlerMap;
     std::unordered_map<std::string, bool> m_ready_list;
     std::unordered_map<std::string, std::vector<std::string>> m_port_ready_list_ref;
-
-    unique_ptr<DBConnector> m_flexCounterDb;
-    unique_ptr<ProducerTable> m_flexCounterGroupTable;
-    unique_ptr<ProducerTable> m_flexCounterTable;
 
     Table m_stateBufferMaximumValueTable;
 

--- a/orchagent/copporch.cpp
+++ b/orchagent/copporch.cpp
@@ -26,6 +26,7 @@ extern sai_object_id_t      gSwitchId;
 extern PortsOrch*           gPortsOrch;
 extern Directory<Orch*>     gDirectory;
 extern bool                 gIsNatSupported;
+extern bool                 gTraditionalFlexCounter;
 
 #define FLEX_COUNTER_UPD_INTERVAL 1
 
@@ -772,7 +773,7 @@ void CoppOrch::doTask(SelectableTimer &timer)
     for (auto it = m_pendingAddToFlexCntr.begin(); it != m_pendingAddToFlexCntr.end(); )
     {
         const auto id = sai_serialize_object_id(it->first);
-        if (m_vidToRidTable->hget("", id, value))
+        if (!gTraditionalFlexCounter || m_vidToRidTable->hget("", id, value))
         {
             SWSS_LOG_INFO("Registering %s, id %s", it->second.c_str(), id.c_str());
 

--- a/orchagent/copporch.cpp
+++ b/orchagent/copporch.cpp
@@ -127,11 +127,9 @@ const uint HOSTIF_TRAP_COUNTER_POLLING_INTERVAL_MS = 10000;
 CoppOrch::CoppOrch(DBConnector* db, string tableName) :
     Orch(db, tableName),
     m_counter_db(std::shared_ptr<DBConnector>(new DBConnector("COUNTERS_DB", 0))),
-    m_flex_db(std::shared_ptr<DBConnector>(new DBConnector("FLEX_COUNTER_DB", 0))),
     m_asic_db(std::shared_ptr<DBConnector>(new DBConnector("ASIC_DB", 0))),
     m_counter_table(std::unique_ptr<Table>(new Table(m_counter_db.get(), COUNTERS_TRAP_NAME_MAP))),
     m_vidToRidTable(std::unique_ptr<Table>(new Table(m_asic_db.get(), "VIDTORID"))),
-    m_flex_counter_group_table(std::unique_ptr<ProducerTable>(new ProducerTable(m_flex_db.get(), FLEX_COUNTER_GROUP_TABLE))),
     m_trap_counter_manager(HOSTIF_TRAP_COUNTER_FLEX_COUNTER_GROUP, StatsMode::READ, HOSTIF_TRAP_COUNTER_POLLING_INTERVAL_MS, false)
 {
     SWSS_LOG_ENTER();
@@ -1206,20 +1204,22 @@ void CoppOrch::initTrapRatePlugin()
     }
 
     std::string trapRatePluginName = "trap_rates.lua";
+    std::string trapSha;
     try
     {
         std::string trapLuaScript = swss::loadLuaScript(trapRatePluginName);
-        std::string trapSha = swss::loadRedisScript(m_counter_db.get(), trapLuaScript);
-
-        vector<FieldValueTuple> fieldValues;
-        fieldValues.emplace_back(FLOW_COUNTER_PLUGIN_FIELD, trapSha);
-        fieldValues.emplace_back(STATS_MODE_FIELD, STATS_MODE_READ);
-        m_flex_counter_group_table->set(HOSTIF_TRAP_COUNTER_FLEX_COUNTER_GROUP, fieldValues);
+        trapSha = swss::loadRedisScript(m_counter_db.get(), trapLuaScript);
     }
     catch (const runtime_error &e)
     {
         SWSS_LOG_ERROR("Trap flex counter groups were not set successfully: %s", e.what());
     }
+
+    setFlexCounterGroupParameter(HOSTIF_TRAP_COUNTER_FLEX_COUNTER_GROUP,
+                                 "", // Do not touch poll interval
+                                 STATS_MODE_READ,
+                                 FLOW_COUNTER_PLUGIN_FIELD,
+                                 trapSha);
     m_trap_rate_plugin_loaded = true;
 }
 

--- a/orchagent/copporch.h
+++ b/orchagent/copporch.h
@@ -98,11 +98,9 @@ protected:
     std::map<sai_object_id_t, std::string> m_pendingAddToFlexCntr;
 
     std::shared_ptr<DBConnector> m_counter_db;
-    std::shared_ptr<DBConnector> m_flex_db;
     std::shared_ptr<DBConnector> m_asic_db;
     std::unique_ptr<Table> m_counter_table;
     std::unique_ptr<Table> m_vidToRidTable;
-    std::unique_ptr<ProducerTable> m_flex_counter_group_table;
 
     FlexCounterManager m_trap_counter_manager;
 

--- a/orchagent/fabricportsorch.cpp
+++ b/orchagent/fabricportsorch.cpp
@@ -80,8 +80,6 @@ FabricPortsOrch::FabricPortsOrch(DBConnector *appl_db, vector<table_name_with_pr
     m_portNamePortCounterTable = unique_ptr<Table>(new Table(m_counter_db.get(), COUNTERS_FABRIC_PORT_NAME_MAP));
     m_fabricCounterTable = unique_ptr<Table>(new Table(m_counter_db.get(), COUNTERS_TABLE));
 
-    m_flex_db = shared_ptr<DBConnector>(new DBConnector("FLEX_COUNTER_DB", 0));
-    m_flexCounterTable = unique_ptr<ProducerTable>(new ProducerTable(m_flex_db.get(), APP_FABRIC_PORT_TABLE_NAME));
     m_appl_db = shared_ptr<DBConnector>(new DBConnector("APPL_DB", 0));
     m_applTable = unique_ptr<Table>(new Table(m_appl_db.get(), APP_FABRIC_MONITOR_PORT_TABLE_NAME));
 

--- a/orchagent/fabricportsorch.h
+++ b/orchagent/fabricportsorch.h
@@ -23,7 +23,6 @@ private:
 
     shared_ptr<DBConnector> m_state_db;
     shared_ptr<DBConnector> m_counter_db;
-    shared_ptr<DBConnector> m_flex_db;
     shared_ptr<DBConnector> m_appl_db;
 
     unique_ptr<Table> m_stateTable;
@@ -31,7 +30,6 @@ private:
     unique_ptr<Table> m_portNamePortCounterTable;
     unique_ptr<Table> m_fabricCounterTable;
     unique_ptr<Table> m_applTable;
-    unique_ptr<ProducerTable> m_flexCounterTable;
 
     swss::SelectableTimer *m_timer = nullptr;
     swss::SelectableTimer *m_debugTimer = nullptr;

--- a/orchagent/flex_counter/flex_counter_manager.cpp
+++ b/orchagent/flex_counter/flex_counter_manager.cpp
@@ -149,9 +149,10 @@ void FlexCounterManager::applyGroupConfiguration()
     {
         sai_redis_flex_counter_group_parameter_t flexCounterGroupParam;
         sai_attribute_t attr;
+        auto &&polling_interval_string = std::to_string(polling_interval);
 
         flexCounterGroupParam.counter_group_name = group_name.c_str();
-        flexCounterGroupParam.poll_interval = std::to_string(polling_interval).c_str();
+        flexCounterGroupParam.poll_interval = polling_interval_string.c_str();
         flexCounterGroupParam.stats_mode = stats_mode_lookup.at(stats_mode).c_str();
         flexCounterGroupParam.operation = status_lookup.at(enabled).c_str();
         if (!fvField(fv_plugin).empty())

--- a/orchagent/flex_counter/flex_counter_manager.cpp
+++ b/orchagent/flex_counter/flex_counter_manager.cpp
@@ -287,7 +287,8 @@ void FlexCounterManager::disableFlexCounterGroup()
 void FlexCounterManager::setCounterIdList(
         const sai_object_id_t object_id,
         const CounterType counter_type,
-        const unordered_set<string>& counter_stats)
+        const unordered_set<string>& counter_stats,
+        const sai_object_id_t switch_id)
 {
     SWSS_LOG_ENTER();
 
@@ -321,7 +322,14 @@ void FlexCounterManager::setCounterIdList(
         counterParam.counter_field_name = counter_type_it->second.c_str();
         attr.value.ptr = &counterParam;
 
-        sai_switch_api->set_switch_attribute(gSwitchId, &attr);
+        if (switch_id == SAI_NULL_OBJECT_ID)
+        {
+            sai_switch_api->set_switch_attribute(gSwitchId, &attr);
+        }
+        else
+        {
+            sai_switch_api->set_switch_attribute(switch_id, &attr);
+        }
     }
     installed_counters.insert(object_id);
 
@@ -332,7 +340,7 @@ void FlexCounterManager::setCounterIdList(
 
 // clearCounterIdList clears all stats that are currently being polled from
 // the given object.
-void FlexCounterManager::clearCounterIdList(const sai_object_id_t object_id)
+void FlexCounterManager::clearCounterIdList(const sai_object_id_t object_id, const sai_object_id_t switch_id)
 {
     SWSS_LOG_ENTER();
 
@@ -359,7 +367,14 @@ void FlexCounterManager::clearCounterIdList(const sai_object_id_t object_id)
         counterParam.counter_key = key.c_str();
         attr.value.ptr = &counterParam;
 
-        sai_switch_api->set_switch_attribute(gSwitchId, &attr);
+        if (switch_id == SAI_NULL_OBJECT_ID)
+        {
+            sai_switch_api->set_switch_attribute(gSwitchId, &attr);
+        }
+        else
+        {
+            sai_switch_api->set_switch_attribute(switch_id, &attr);
+        }
     }
     installed_counters.erase(counter_it);
 

--- a/orchagent/flex_counter/flex_counter_manager.h
+++ b/orchagent/flex_counter/flex_counter_manager.h
@@ -72,8 +72,9 @@ class FlexCounterManager
         void setCounterIdList(
                 const sai_object_id_t object_id,
                 const CounterType counter_type,
-                const std::unordered_set<std::string>& counter_stats);
-        void clearCounterIdList(const sai_object_id_t object_id);
+                const std::unordered_set<std::string>& counter_stats,
+                const sai_object_id_t switch_id=SAI_NULL_OBJECT_ID);
+        void clearCounterIdList(const sai_object_id_t object_id, const sai_object_id_t switch_id=SAI_NULL_OBJECT_ID);
 
         const std::string& getGroupName() const
         {

--- a/orchagent/flex_counter/flex_counter_manager.h
+++ b/orchagent/flex_counter/flex_counter_manager.h
@@ -12,6 +12,7 @@
 
 extern "C" {
 #include "sai.h"
+#include "sairedis.h"
 }
 
 enum class StatsMode

--- a/orchagent/flex_counter/flex_counter_manager.h
+++ b/orchagent/flex_counter/flex_counter_manager.h
@@ -54,7 +54,7 @@ class FlexCounterManager
         {}
 
         FlexCounterManager(
-                const std::string& db_name,
+                const bool is_gearbox,
                 const std::string& group_name,
                 const StatsMode stats_mode,
                 const uint polling_interval,
@@ -74,7 +74,7 @@ class FlexCounterManager
                 const CounterType counter_type,
                 const std::unordered_set<std::string>& counter_stats,
                 const sai_object_id_t switch_id=SAI_NULL_OBJECT_ID);
-        void clearCounterIdList(const sai_object_id_t object_id, const sai_object_id_t switch_id=SAI_NULL_OBJECT_ID);
+        void clearCounterIdList(const sai_object_id_t object_id);
 
         const std::string& getGroupName() const
         {
@@ -111,11 +111,8 @@ class FlexCounterManager
         uint polling_interval;
         bool enabled;
         swss::FieldValueTuple fv_plugin;
-        std::unordered_set<sai_object_id_t> installed_counters;
-
-        std::shared_ptr<swss::DBConnector> flex_counter_db = nullptr;
-        std::shared_ptr<swss::ProducerTable> flex_counter_group_table = nullptr;
-        std::shared_ptr<swss::ProducerTable> flex_counter_table = nullptr;
+        std::unordered_map<sai_object_id_t, sai_object_id_t> installed_counters;
+        bool is_gearbox;
 
         static const std::unordered_map<StatsMode, std::string> stats_mode_lookup;
         static const std::unordered_map<bool, std::string> status_lookup;

--- a/orchagent/flexcounterorch.cpp
+++ b/orchagent/flexcounterorch.cpp
@@ -165,11 +165,14 @@ void FlexCounterOrch::doTask(Consumer &consumer)
                         attr.value.ptr = (void*)&flexCounterGroupParam;
                         sai_switch_api->set_switch_attribute(gSwitchId, &attr);
 
-                        auto &gbPhyOidMap =  gPortsOrch->getGearboxPhyOidMap();
-                        std::map<int, sai_object_id_t>::const_iterator it = gbPhyOidMap.begin();
-                        while (it != gbPhyOidMap.end()) {
-                            sai_switch_api->set_switch_attribute(it->second, &attr);
-                            it++;
+                        if (gPortsOrch)
+                        {
+                            auto &gbPhyOidMap =  gPortsOrch->getGearboxPhyOidMap();
+                            std::map<int, sai_object_id_t>::const_iterator it = gbPhyOidMap.begin();
+                            while (it != gbPhyOidMap.end()) {
+                                sai_switch_api->set_switch_attribute(it->second, &attr);
+                                it++;
+                            }
                         }
                     }
                 }

--- a/orchagent/flexcounterorch.h
+++ b/orchagent/flexcounterorch.h
@@ -55,10 +55,6 @@ public:
     bool bake() override;
 
 private:
-    std::shared_ptr<swss::DBConnector> m_flexCounterDb = nullptr;
-    std::shared_ptr<swss::ProducerTable> m_flexCounterGroupTable = nullptr;
-    std::shared_ptr<swss::DBConnector> m_gbflexCounterDb = nullptr;
-    std::shared_ptr<ProducerTable> m_gbflexCounterGroupTable = nullptr;
     bool m_port_counter_enabled = false;
     bool m_port_buffer_drop_counter_enabled = false;
     bool m_queue_enabled = false;

--- a/orchagent/intfsorch.h
+++ b/orchagent/intfsorch.h
@@ -18,6 +18,11 @@ extern MacAddress gMacAddress;
 
 #define RIF_STAT_COUNTER_FLEX_COUNTER_GROUP "RIF_STAT_COUNTER"
 #define RIF_RATE_COUNTER_FLEX_COUNTER_GROUP "RIF_RATE_COUNTER"
+#define RIF_FLEX_STAT_COUNTER_POLL_MSECS "1000"
+
+const string rif_stat_counter_flex_counter_group = RIF_STAT_COUNTER_FLEX_COUNTER_GROUP;
+const string rif_rate_counter_flex_counter_group = RIF_RATE_COUNTER_FLEX_COUNTER_GROUP;
+const string rif_flex_stat_counter_poll_msecs = RIF_FLEX_STAT_COUNTER_POLL_MSECS;
 
 struct IntfsEntry
 {
@@ -84,13 +89,10 @@ private:
     void doTask(SelectableTimer &timer);
 
     shared_ptr<DBConnector> m_counter_db;
-    shared_ptr<DBConnector> m_flex_db;
     shared_ptr<DBConnector> m_asic_db;
     unique_ptr<Table> m_rifNameTable;
     unique_ptr<Table> m_rifTypeTable;
     unique_ptr<Table> m_vidToRidTable;
-    unique_ptr<ProducerTable> m_flexCounterTable;
-    unique_ptr<ProducerTable> m_flexCounterGroupTable;
 
     std::set<std::string> m_removingIntfses;
 

--- a/orchagent/macsecorch.cpp
+++ b/orchagent/macsecorch.cpp
@@ -2352,16 +2352,16 @@ void MACsecOrch::installCounter(
     switch(counter_type)
     {
         case CounterType::MACSEC_SA_ATTR:
-            MACsecSaAttrStatManager(ctx).setCounterIdList(obj_id, counter_type, counter_stats);
+            MACsecSaAttrStatManager(ctx).setCounterIdList(obj_id, counter_type, counter_stats, *ctx.get_switch_id());
             break;
 
         case CounterType::MACSEC_SA:
-            MACsecSaStatManager(ctx).setCounterIdList(obj_id, counter_type, counter_stats);
+            MACsecSaStatManager(ctx).setCounterIdList(obj_id, counter_type, counter_stats, *ctx.get_switch_id());
             MACsecCountersMap(ctx).hset("", obj_name, sai_serialize_object_id(obj_id));
             break;
 
         case CounterType::MACSEC_FLOW:
-            MACsecFlowStatManager(ctx).setCounterIdList(obj_id, counter_type, counter_stats);
+            MACsecFlowStatManager(ctx).setCounterIdList(obj_id, counter_type, counter_stats, *ctx.get_switch_id());
             break;
 
         default:
@@ -2381,16 +2381,16 @@ void MACsecOrch::uninstallCounter(
     switch(counter_type)
     {
         case CounterType::MACSEC_SA_ATTR:
-            MACsecSaAttrStatManager(ctx).clearCounterIdList(obj_id);
+            MACsecSaAttrStatManager(ctx).clearCounterIdList(obj_id, *ctx.get_switch_id());
             break;
 
         case CounterType::MACSEC_SA:
-            MACsecSaStatManager(ctx).clearCounterIdList(obj_id);
+            MACsecSaStatManager(ctx).clearCounterIdList(obj_id, *ctx.get_switch_id());
             MACsecCountersMap(ctx).hdel("", obj_name);
             break;
 
         case CounterType::MACSEC_FLOW:
-            MACsecFlowStatManager(ctx).clearCounterIdList(obj_id);
+            MACsecFlowStatManager(ctx).clearCounterIdList(obj_id, *ctx.get_switch_id());
             break;
 
         default:

--- a/orchagent/macsecorch.cpp
+++ b/orchagent/macsecorch.cpp
@@ -621,17 +621,17 @@ MACsecOrch::MACsecOrch(
                                 StatsMode::READ,
                                 MACSEC_STAT_POLLING_INTERVAL_MS, true),
                             m_gb_macsec_sa_attr_manager(
-                                "GB_FLEX_COUNTER_DB",
+                                true,
                                 COUNTERS_MACSEC_SA_ATTR_GROUP,
                                 StatsMode::READ,
                                 MACSEC_STAT_XPN_POLLING_INTERVAL_MS, true),
                             m_gb_macsec_sa_stat_manager(
-                                "GB_FLEX_COUNTER_DB",
+                                true,
                                 COUNTERS_MACSEC_SA_GROUP,
                                 StatsMode::READ,
                                 MACSEC_STAT_POLLING_INTERVAL_MS, true),
                             m_gb_macsec_flow_stat_manager(
-                                "GB_FLEX_COUNTER_DB",
+                                true,
                                 COUNTERS_MACSEC_FLOW_GROUP,
                                 StatsMode::READ,
                                 MACSEC_STAT_POLLING_INTERVAL_MS, true)
@@ -2381,16 +2381,16 @@ void MACsecOrch::uninstallCounter(
     switch(counter_type)
     {
         case CounterType::MACSEC_SA_ATTR:
-            MACsecSaAttrStatManager(ctx).clearCounterIdList(obj_id, *ctx.get_switch_id());
+            MACsecSaAttrStatManager(ctx).clearCounterIdList(obj_id);
             break;
 
         case CounterType::MACSEC_SA:
-            MACsecSaStatManager(ctx).clearCounterIdList(obj_id, *ctx.get_switch_id());
+            MACsecSaStatManager(ctx).clearCounterIdList(obj_id);
             MACsecCountersMap(ctx).hdel("", obj_name);
             break;
 
         case CounterType::MACSEC_FLOW:
-            MACsecFlowStatManager(ctx).clearCounterIdList(obj_id, *ctx.get_switch_id());
+            MACsecFlowStatManager(ctx).clearCounterIdList(obj_id);
             break;
 
         default:

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -68,7 +68,7 @@ int32_t gVoqMaxCores = 0;
 uint32_t gCfgSystemPorts = 0;
 string gMyHostName = "";
 string gMyAsicName = "";
-bool gTraditionalFlexCounter = true;
+bool gTraditionalFlexCounter = false;
 
 void usage()
 {
@@ -91,7 +91,7 @@ void usage()
     cout << "    -j sairedis_rec_filename: sairedis record log filename(default sairedis.rec)" << endl;
     cout << "    -k max bulk size in bulk mode (default 1000)" << endl;
     cout << "    -q zmq_server_address: ZMQ server address (default disable ZMQ)" << endl;
-    cout << "    -c counter mode (traditional|asic_db), default: traditional" << endl;
+    cout << "    -c counter mode (traditional|asic_db), default: asic_db" << endl;
 }
 
 void sighup_handler(int signo)
@@ -398,9 +398,9 @@ int main(int argc, char **argv)
             sai_deserialize_redis_communication_mode(optarg, gRedisCommunicationMode);
             break;
         case 'c':
-            if (optarg == string("asic_db"))
+            if (optarg == string("traditional"))
             {
-                gTraditionalFlexCounter = false;
+                gTraditionalFlexCounter = true;
             }
             break;
         case 'f':
@@ -454,6 +454,7 @@ int main(int argc, char **argv)
     /* Initialize sairedis */
     initSaiApi();
     initSaiRedis();
+    initFlexCounterTables();
 
     /* Initialize remaining recorder parameters  */
     Recorder::Instance().swss.setRecord(

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -68,10 +68,11 @@ int32_t gVoqMaxCores = 0;
 uint32_t gCfgSystemPorts = 0;
 string gMyHostName = "";
 string gMyAsicName = "";
+bool gTraditionalFlexCounter = true;
 
 void usage()
 {
-    cout << "usage: orchagent [-h] [-r record_type] [-d record_location] [-f swss_rec_filename] [-j sairedis_rec_filename] [-b batch_size] [-m MAC] [-i INST_ID] [-s] [-z mode] [-k bulk_size] [-q zmq_server_address]" << endl;
+    cout << "usage: orchagent [-h] [-r record_type] [-d record_location] [-f swss_rec_filename] [-j sairedis_rec_filename] [-b batch_size] [-m MAC] [-i INST_ID] [-s] [-z mode] [-k bulk_size] [-q zmq_server_address] [-c mode]" << endl;
     cout << "    -h: display this message" << endl;
     cout << "    -r record_type: record orchagent logs with type (default 3)" << endl;
     cout << "                    Bit 0: sairedis.rec, Bit 1: swss.rec, Bit 2: responsepublisher.rec. For example:" << endl;
@@ -90,6 +91,7 @@ void usage()
     cout << "    -j sairedis_rec_filename: sairedis record log filename(default sairedis.rec)" << endl;
     cout << "    -k max bulk size in bulk mode (default 1000)" << endl;
     cout << "    -q zmq_server_address: ZMQ server address (default disable ZMQ)" << endl;
+    cout << "    -c counter mode (traditional|asic_db), default: traditional" << endl;
 }
 
 void sighup_handler(int signo)
@@ -344,7 +346,7 @@ int main(int argc, char **argv)
     string responsepublisher_rec_filename = Recorder::RESPPUB_FNAME;
     int record_type = 3; // Only swss and sairedis recordings enabled by default.
 
-    while ((opt = getopt(argc, argv, "b:m:r:f:j:d:i:hsz:k:q:")) != -1)
+    while ((opt = getopt(argc, argv, "b:m:r:f:j:d:i:hsz:k:q:c:")) != -1)
     {
         switch (opt)
         {
@@ -394,6 +396,12 @@ int main(int argc, char **argv)
             break;
         case 'z':
             sai_deserialize_redis_communication_mode(optarg, gRedisCommunicationMode);
+            break;
+        case 'c':
+            if (optarg == string("asic_db"))
+            {
+                gTraditionalFlexCounter = false;
+            }
             break;
         case 'f':
 

--- a/orchagent/p4orch/tests/fake_portorch.cpp
+++ b/orchagent/p4orch/tests/fake_portorch.cpp
@@ -332,11 +332,6 @@ const gearbox_phy_t *PortsOrch::getGearboxPhy(const Port &port)
     return nullptr;
 }
 
-const map<int, sai_object_id_t>& PortsOrch::getGearboxPhyOidMap()
-{
-    return m_gearboxPhyOidMap;
-}
-
 bool PortsOrch::getPortIPG(sai_object_id_t port_id, uint32_t &ipg)
 {
     return true;

--- a/orchagent/p4orch/tests/fake_portorch.cpp
+++ b/orchagent/p4orch/tests/fake_portorch.cpp
@@ -332,6 +332,11 @@ const gearbox_phy_t *PortsOrch::getGearboxPhy(const Port &port)
     return nullptr;
 }
 
+const map<int, sai_object_id_t>& PortsOrch::getGearboxPhyOidMap()
+{
+    return m_gearboxPhyOidMap;
+}
+
 bool PortsOrch::getPortIPG(sai_object_id_t port_id, uint32_t &ipg)
 {
     return true;

--- a/orchagent/pfcwdorch.h
+++ b/orchagent/pfcwdorch.h
@@ -15,6 +15,8 @@ extern "C" {
 
 #define PFC_WD_FLEX_COUNTER_GROUP       "PFC_WD"
 
+const string pfc_wd_flex_counter_group = PFC_WD_FLEX_COUNTER_GROUP;
+
 enum class PfcWdAction
 {
     PFC_WD_ACTION_UNKNOWN,
@@ -136,10 +138,6 @@ private:
     const vector<sai_port_stat_t> c_portStatIds;
     const vector<sai_queue_stat_t> c_queueStatIds;
     const vector<sai_queue_attr_t> c_queueAttrIds;
-
-    shared_ptr<DBConnector> m_flexCounterDb = nullptr;
-    shared_ptr<ProducerTable> m_flexCounterTable = nullptr;
-    shared_ptr<ProducerTable> m_flexCounterGroupTable = nullptr;
 
     bool m_bigRedSwitchFlag = false;
     int m_pollInterval;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3320,10 +3320,10 @@ bool PortsOrch::initPort(const PortConfig &port)
                     auto gbport_counter_stats = generateCounterStats(PORT_STAT_COUNTER_FLEX_COUNTER_GROUP, true);
                     if (p.m_system_side_id)
                         gb_port_stat_manager.setCounterIdList(p.m_system_side_id,
-                                CounterType::PORT, gbport_counter_stats);
+                                CounterType::PORT, gbport_counter_stats, p.m_switch_id);
                     if (p.m_line_side_id)
                         gb_port_stat_manager.setCounterIdList(p.m_line_side_id,
-                                CounterType::PORT, gbport_counter_stats);
+                                CounterType::PORT, gbport_counter_stats, p.m_switch_id);
                 }
                 if (flex_counters_orch->getPortBufferDropCountersState())
                 {
@@ -7619,10 +7619,10 @@ void PortsOrch::generatePortCounterMap()
                 CounterType::PORT, port_counter_stats);
         if (it.second.m_system_side_id)
             gb_port_stat_manager.setCounterIdList(it.second.m_system_side_id,
-                    CounterType::PORT, gbport_counter_stats);
+                    CounterType::PORT, gbport_counter_stats, it.second.m_switch_id);
         if (it.second.m_line_side_id)
             gb_port_stat_manager.setCounterIdList(it.second.m_line_side_id,
-                    CounterType::PORT, gbport_counter_stats);
+                    CounterType::PORT, gbport_counter_stats, it.second.m_switch_id);
     }
 
     m_isPortCounterMapGenerated = true;
@@ -8262,6 +8262,12 @@ void PortsOrch::initGearbox()
 
         m_gb_counter_db = shared_ptr<DBConnector>(new DBConnector("GB_COUNTERS_DB", 0));
         m_gbcounterTable = unique_ptr<Table>(new Table(m_gb_counter_db.get(), COUNTERS_PORT_NAME_MAP));
+
+        std::map<int, gearbox_phy_t>::iterator it = m_gearboxPhyMap.begin();
+        while (it != m_gearboxPhyMap.end()) {
+            sai_deserialize_object_id(it->second.phy_oid, m_gearboxPhyOidMap[it->first]);
+            it++;
+        }
     }
 }
 
@@ -8591,6 +8597,11 @@ const gearbox_phy_t* PortsOrch::getGearboxPhy(const Port &port)
     }
 
     return &phy->second;
+}
+
+const map<int, sai_object_id_t>& PortsOrch::getGearboxPhyOidMap()
+{
+    return m_gearboxPhyOidMap;
 }
 
 bool PortsOrch::getPortIPG(sai_object_id_t port_id, uint32_t &ipg)

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -31,6 +31,10 @@
 #define QUEUE_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP "QUEUE_WATERMARK_STAT_COUNTER"
 #define PG_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP "PG_WATERMARK_STAT_COUNTER"
 #define PG_DROP_STAT_COUNTER_FLEX_COUNTER_GROUP "PG_DROP_STAT_COUNTER"
+#define QUEUE_WATERMARK_FLEX_STAT_COUNTER_POLL_MSECS "60000"
+#define PG_WATERMARK_FLEX_STAT_COUNTER_POLL_MSECS    "60000"
+#define PG_DROP_FLEX_STAT_COUNTER_POLL_MSECS         "10000"
+#define PORT_RATE_FLEX_COUNTER_POLLING_INTERVAL_MS   "1000"
 
 typedef std::vector<sai_uint32_t> PortSupportedSpeeds;
 typedef std::set<sai_port_fec_mode_t> PortSupportedFecModes;
@@ -225,7 +229,6 @@ public:
     bool getRecircPort(Port &p, Port::Role role);
 
     const gearbox_phy_t* getGearboxPhy(const Port &port);
-    const map<int, sai_object_id_t>& getGearboxPhyOidMap();
 
     bool getPortIPG(sai_object_id_t port_id, uint32_t &ipg);
     bool setPortIPG(sai_object_id_t port_id, uint32_t ipg);
@@ -256,8 +259,6 @@ private:
     unique_ptr<Table> m_pgPortTable;
     unique_ptr<Table> m_pgIndexTable;
     unique_ptr<Table> m_stateBufferMaximumValueTable;
-    unique_ptr<ProducerTable> m_flexCounterTable;
-    unique_ptr<ProducerTable> m_flexCounterGroupTable;
     Table m_portStateTable;
 
     std::string getQueueWatermarkFlexCounterTableKey(std::string s);
@@ -266,7 +267,6 @@ private:
     std::string getPortRateFlexCounterTableKey(std::string s);
 
     shared_ptr<DBConnector> m_counter_db;
-    shared_ptr<DBConnector> m_flex_db;
     shared_ptr<DBConnector> m_state_db;
     shared_ptr<DBConnector> m_notificationsDb;
 
@@ -310,7 +310,6 @@ private:
     map<int, gearbox_lane_t> m_gearboxLaneMap;
     map<int, gearbox_port_t> m_gearboxPortMap;
     map<sai_object_id_t, tuple<sai_object_id_t, sai_object_id_t>> m_gearboxPortListLaneMap;
-    map<int, sai_object_id_t> m_gearboxPhyOidMap;
 
     unordered_set<string> m_vlanPorts;
     port_config_state_t m_portConfigState = PORT_CONFIG_MISSING;

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -225,6 +225,7 @@ public:
     bool getRecircPort(Port &p, Port::Role role);
 
     const gearbox_phy_t* getGearboxPhy(const Port &port);
+    const map<int, sai_object_id_t>& getGearboxPhyOidMap();
 
     bool getPortIPG(sai_object_id_t port_id, uint32_t &ipg);
     bool setPortIPG(sai_object_id_t port_id, uint32_t ipg);
@@ -309,6 +310,7 @@ private:
     map<int, gearbox_lane_t> m_gearboxLaneMap;
     map<int, gearbox_port_t> m_gearboxPortMap;
     map<sai_object_id_t, tuple<sai_object_id_t, sai_object_id_t>> m_gearboxPortListLaneMap;
+    map<int, sai_object_id_t> m_gearboxPhyOidMap;
 
     unordered_set<string> m_vlanPorts;
     port_config_state_t m_portConfigState = PORT_CONFIG_MISSING;

--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -84,6 +84,16 @@ sai_dash_vip_api_t*                 sai_dash_vip_api;
 sai_dash_direction_lookup_api_t*    sai_dash_direction_lookup_api;
 
 extern sai_object_id_t gSwitchId;
+extern bool gTraditionalFlexCounter;
+
+vector<sai_object_id_t> gGearboxOids;
+
+unique_ptr<DBConnector> gFlexCounterDb;
+unique_ptr<ProducerTable> gFlexCounterGroupTable;
+unique_ptr<ProducerTable> gFlexCounterTable;
+unique_ptr<DBConnector> gGearBoxFlexCounterDb;
+unique_ptr<ProducerTable> gGearBoxFlexCounterGroupTable;
+unique_ptr<ProducerTable> gGearBoxFlexCounterTable;
 
 static map<string, sai_switch_hardware_access_bus_t> hardware_access_map =
 {
@@ -256,6 +266,20 @@ void initSaiApi()
     sai_log_set(SAI_API_BFD,                    SAI_LOG_LEVEL_NOTICE);
     sai_log_set(SAI_API_MY_MAC,                 SAI_LOG_LEVEL_NOTICE);
     sai_log_set(SAI_API_GENERIC_PROGRAMMABLE,   SAI_LOG_LEVEL_NOTICE);
+}
+
+void initFlexCounterTables()
+{
+    if (gTraditionalFlexCounter)
+    {
+        gFlexCounterDb = std::make_unique<DBConnector>("FLEX_COUNTER_DB", 0);
+        gFlexCounterTable = std::make_unique<ProducerTable>(gFlexCounterDb.get(), FLEX_COUNTER_TABLE);
+        gFlexCounterGroupTable = std::make_unique<ProducerTable>(gFlexCounterDb.get(), FLEX_COUNTER_GROUP_TABLE);
+
+        gGearBoxFlexCounterDb = std::make_unique<DBConnector>("GB_FLEX_COUNTER_DB", 0);
+        gGearBoxFlexCounterTable = std::make_unique<ProducerTable>(gGearBoxFlexCounterDb.get(), FLEX_COUNTER_TABLE);
+        gGearBoxFlexCounterGroupTable = std::make_unique<ProducerTable>(gGearBoxFlexCounterDb.get(), FLEX_COUNTER_GROUP_TABLE);
+    }
 }
 
 void initSaiRedis()
@@ -477,6 +501,9 @@ sai_status_t initSaiPhyApi(swss::gearbox_phy_t *phy)
             phy->firmware_major_version = string(attr.value.chardata);
         }
     }
+
+    gGearboxOids.push_back(phyOid);
+
     return status;
 }
 
@@ -799,4 +826,271 @@ void handleSaiFailure(bool abort_on_failure)
     {
         abort();
     }
+}
+
+
+inline void initSaiRedisCounterEmptyParameter(sai_s8_list_t &sai_s8_list)
+{
+    sai_s8_list.list = nullptr;
+    sai_s8_list.count = 0;
+}
+
+inline void initSaiRedisCounterEmptyParameter(sai_redis_flex_counter_group_parameter_t &flex_counter_group_param)
+{
+    initSaiRedisCounterEmptyParameter(flex_counter_group_param.poll_interval);
+    initSaiRedisCounterEmptyParameter(flex_counter_group_param.operation);
+    initSaiRedisCounterEmptyParameter(flex_counter_group_param.stats_mode);
+    initSaiRedisCounterEmptyParameter(flex_counter_group_param.plugin_name);
+    initSaiRedisCounterEmptyParameter(flex_counter_group_param.plugins);
+}
+
+inline void initSaiRedisCounterParameterFromString(sai_s8_list_t &sai_s8_list, const std::string &str)
+{
+    if (str.length() > 0)
+    {
+        sai_s8_list.list = (int8_t*)const_cast<char *>(str.c_str());
+        sai_s8_list.count = (uint32_t)str.length();
+    }
+    else
+    {
+        sai_s8_list.list = nullptr;
+        sai_s8_list.count = 0;
+    }
+}
+
+inline void notifySyncdCounterOperation(bool is_gearbox, const sai_attribute_t &attr)
+{
+    if (sai_switch_api == nullptr)
+    {
+        // This can happen during destrction of the orchagent daemon.
+        SWSS_LOG_ERROR("sai_switch_api is NULL");
+        return;
+    }
+
+    if (!is_gearbox)
+    {
+        sai_switch_api->set_switch_attribute(gSwitchId, &attr);
+    }
+    else
+    {
+        for (auto gearbox_oid : gGearboxOids)
+        {
+            sai_switch_api->set_switch_attribute(gearbox_oid, &attr);
+        }
+    }
+}
+
+inline void operateFlexCounterDbSingleField(std::vector<FieldValueTuple> &fvTuples,
+                                            const string &field, const string &value)
+{
+    if (!field.empty() && !value.empty())
+    {
+        fvTuples.emplace_back(field, value);
+    }
+}
+
+inline void operateFlexCounterGroupDatabase(const string &group,
+                                            const string &poll_interval,
+                                            const string &stats_mode,
+                                            const string &plugin_name,
+                                            const string &plugins,
+                                            const string &operation,
+                                            bool is_gearbox)
+{
+    std::vector<FieldValueTuple> fvTuples;
+    auto &flexCounterGroupTable = is_gearbox ? gFlexCounterGroupTable : gGearBoxFlexCounterGroupTable;
+
+    operateFlexCounterDbSingleField(fvTuples, POLL_INTERVAL_FIELD, poll_interval);
+    operateFlexCounterDbSingleField(fvTuples, STATS_MODE_FIELD, stats_mode);
+    operateFlexCounterDbSingleField(fvTuples, plugin_name, plugins);
+    operateFlexCounterDbSingleField(fvTuples, FLEX_COUNTER_STATUS_FIELD, operation);
+
+    flexCounterGroupTable->set(group, fvTuples);
+}
+void setFlexCounterGroupParameter(const string &group,
+                                  const string &poll_interval,
+                                  const string &stats_mode,
+                                  const string &plugin_name,
+                                  const string &plugins,
+                                  const string &operation,
+                                  bool is_gearbox)
+{
+    if (gTraditionalFlexCounter)
+    {
+        operateFlexCounterGroupDatabase(group, poll_interval, stats_mode, plugin_name, plugins, operation, is_gearbox);
+        return;
+    }
+
+    sai_attribute_t attr;
+    sai_redis_flex_counter_group_parameter_t flex_counter_group_param;
+
+    attr.id = SAI_REDIS_SWITCH_ATTR_FLEX_COUNTER_GROUP;
+    attr.value.ptr = &flex_counter_group_param;
+
+    initSaiRedisCounterParameterFromString(flex_counter_group_param.counter_group_name, group);
+    initSaiRedisCounterParameterFromString(flex_counter_group_param.poll_interval, poll_interval);
+    initSaiRedisCounterParameterFromString(flex_counter_group_param.operation, operation);
+    initSaiRedisCounterParameterFromString(flex_counter_group_param.stats_mode, stats_mode);
+    initSaiRedisCounterParameterFromString(flex_counter_group_param.plugin_name, plugin_name);
+    initSaiRedisCounterParameterFromString(flex_counter_group_param.plugins, plugins);
+
+    notifySyncdCounterOperation(is_gearbox, attr);
+}
+
+void setFlexCounterGroupOperation(const string &group,
+                                  const string &operation,
+                                  bool is_gearbox)
+{
+    if (gTraditionalFlexCounter)
+    {
+        operateFlexCounterGroupDatabase(group, "", "", "", "", operation, is_gearbox);
+        return;
+    }
+
+    sai_attribute_t attr;
+    sai_redis_flex_counter_group_parameter_t flex_counter_group_param;
+
+    attr.id = SAI_REDIS_SWITCH_ATTR_FLEX_COUNTER_GROUP;
+    attr.value.ptr = &flex_counter_group_param;
+
+    initSaiRedisCounterEmptyParameter(flex_counter_group_param);
+    initSaiRedisCounterParameterFromString(flex_counter_group_param.counter_group_name, group);
+    initSaiRedisCounterParameterFromString(flex_counter_group_param.operation, operation);
+
+    notifySyncdCounterOperation(is_gearbox, attr);
+}
+
+void setFlexCounterGroupPollInterval(const string &group,
+                                     const string &poll_interval,
+                                     bool is_gearbox)
+{
+    if (gTraditionalFlexCounter)
+    {
+        operateFlexCounterGroupDatabase(group, poll_interval, "", "", "", "", is_gearbox);
+        return;
+    }
+
+    sai_attribute_t attr;
+    sai_redis_flex_counter_group_parameter_t flex_counter_group_param;
+
+    attr.id = SAI_REDIS_SWITCH_ATTR_FLEX_COUNTER_GROUP;
+    attr.value.ptr = &flex_counter_group_param;
+
+    initSaiRedisCounterEmptyParameter(flex_counter_group_param);
+    initSaiRedisCounterParameterFromString(flex_counter_group_param.counter_group_name, group);
+    initSaiRedisCounterParameterFromString(flex_counter_group_param.poll_interval, poll_interval);
+
+    notifySyncdCounterOperation(is_gearbox, attr);
+}
+
+void setFlexCounterGroupStatsMode(const std::string &group,
+                                  const std::string &stats_mode,
+                                  bool is_gearbox)
+{
+    if (gTraditionalFlexCounter)
+    {
+        operateFlexCounterGroupDatabase(group, "", stats_mode, "", "", "", is_gearbox);
+        return;
+    }
+
+    sai_attribute_t attr;
+    sai_redis_flex_counter_group_parameter_t flex_counter_group_param;
+
+    attr.id = SAI_REDIS_SWITCH_ATTR_FLEX_COUNTER_GROUP;
+    attr.value.ptr = &flex_counter_group_param;
+
+    initSaiRedisCounterEmptyParameter(flex_counter_group_param);
+    initSaiRedisCounterParameterFromString(flex_counter_group_param.counter_group_name, group);
+    initSaiRedisCounterParameterFromString(flex_counter_group_param.stats_mode, stats_mode);
+
+    notifySyncdCounterOperation(is_gearbox, attr);
+}
+
+void delFlexCounterGroup(const std::string &group,
+                         bool is_gearbox)
+{
+    if (gTraditionalFlexCounter)
+    {
+        auto &flexCounterGroupTable = is_gearbox ? gFlexCounterGroupTable : gGearBoxFlexCounterGroupTable;
+
+        if (flexCounterGroupTable != nullptr)
+        {
+            flexCounterGroupTable->del(group);
+        }
+
+        return;
+    }
+
+    sai_attribute_t attr;
+    sai_redis_flex_counter_group_parameter_t flex_counter_group_param;
+
+    attr.id = SAI_REDIS_SWITCH_ATTR_FLEX_COUNTER_GROUP;
+    attr.value.ptr = &flex_counter_group_param;
+
+    initSaiRedisCounterEmptyParameter(flex_counter_group_param);
+    initSaiRedisCounterParameterFromString(flex_counter_group_param.counter_group_name, group);
+
+    notifySyncdCounterOperation(is_gearbox, attr);
+}
+
+void startFlexCounterPolling(sai_object_id_t switch_oid,
+                             const std::string &key,
+                             const std::string &counter_ids,
+                             const std::string &counter_field_name,
+                             const std::string &stats_mode)
+{
+    if (gTraditionalFlexCounter)
+    {
+        std::vector<FieldValueTuple> fvTuples;
+        auto &flexCounterTable = switch_oid == gSwitchId ? gFlexCounterTable : gGearBoxFlexCounterTable;
+
+        operateFlexCounterDbSingleField(fvTuples, counter_field_name, counter_ids);
+        operateFlexCounterDbSingleField(fvTuples, STATS_MODE_FIELD, stats_mode);
+
+        flexCounterTable->set(key, fvTuples);
+
+        return;
+    }
+
+    sai_attribute_t attr;
+    sai_redis_flex_counter_parameter_t flex_counter_param;
+
+    attr.id = SAI_REDIS_SWITCH_ATTR_FLEX_COUNTER;
+    attr.value.ptr = &flex_counter_param;
+
+    initSaiRedisCounterParameterFromString(flex_counter_param.counter_key, key);
+    initSaiRedisCounterParameterFromString(flex_counter_param.counter_ids, counter_ids);
+    initSaiRedisCounterParameterFromString(flex_counter_param.counter_field_name, counter_field_name);
+    initSaiRedisCounterParameterFromString(flex_counter_param.stats_mode, stats_mode);
+
+    sai_switch_api->set_switch_attribute(switch_oid, &attr);
+}
+
+void stopFlexCounterPolling(sai_object_id_t switch_oid,
+                            const std::string &key)
+{
+    if (gTraditionalFlexCounter)
+    {
+        auto &flexCounterTable = switch_oid == gSwitchId ? gFlexCounterTable : gGearBoxFlexCounterTable;
+
+        if (flexCounterTable != nullptr)
+        {
+            flexCounterTable->del(key);
+        }
+
+        return;
+    }
+
+    sai_attribute_t attr;
+    sai_redis_flex_counter_parameter_t flex_counter_param;
+
+    attr.id = SAI_REDIS_SWITCH_ATTR_FLEX_COUNTER;
+    attr.value.ptr = &flex_counter_param;
+
+    initSaiRedisCounterParameterFromString(flex_counter_param.counter_key, key);
+    initSaiRedisCounterEmptyParameter(flex_counter_param.counter_ids);
+    initSaiRedisCounterEmptyParameter(flex_counter_param.counter_field_name);
+    initSaiRedisCounterEmptyParameter(flex_counter_param.stats_mode);
+
+    sai_switch_api->set_switch_attribute(switch_oid, &attr);
 }

--- a/orchagent/saihelper.h
+++ b/orchagent/saihelper.h
@@ -4,10 +4,13 @@
 
 #include <string>
 #include "orch.h"
+#include "producertable.h"
+#include <sairedis.h>
 
 #define IS_ATTR_ID_IN_RANGE(attrId, objectType, attrPrefix) \
     ((attrId) >= SAI_ ## objectType ## _ATTR_ ## attrPrefix ## _START && (attrId) <= SAI_ ## objectType ## _ATTR_ ## attrPrefix ## _END)
 
+void initFlexCounterTables();
 void initSaiApi();
 void initSaiRedis();
 sai_status_t initSaiPhyApi(swss::gearbox_phy_t *phy);
@@ -19,3 +22,31 @@ task_process_status handleSaiRemoveStatus(sai_api_t api, sai_status_t status, vo
 task_process_status handleSaiGetStatus(sai_api_t api, sai_status_t status, void *context = nullptr);
 bool parseHandleSaiStatusFailure(task_process_status status);
 void handleSaiFailure(bool abort_on_failure);
+
+void setFlexCounterGroupParameter(const std::string &group,
+                                  const std::string &poll_interval,
+                                  const std::string &stats_mode,
+                                  const std::string &plugin_name="",
+                                  const std::string &plugins="",
+                                  const std::string &operation="",
+                                  bool is_gearbox=false);
+void setFlexCounterGroupPollInterval(const std::string &group,
+                                     const std::string &poll_interval,
+                                     bool is_gearbox=false);
+void setFlexCounterGroupOperation(const std::string &group,
+                                  const std::string &operation,
+                                  bool is_gearbox=false);
+void setFlexCounterGroupStatsMode(const std::string &group,
+                                  const std::string &stats_mode,
+                                  bool is_gearbox=false);
+
+void delFlexCounterGroup(const std::string &group,
+                         bool is_gearbox=false);
+
+void startFlexCounterPolling(sai_object_id_t switch_oid,
+                             const std::string &key,
+                             const std::string &counter_ids,
+                             const std::string &counter_field_name,
+                             const std::string &stats_mode="");
+void stopFlexCounterPolling(sai_object_id_t switch_oid,
+                            const std::string &key);

--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -1220,7 +1220,10 @@ VxlanTunnelOrch::VxlanTunnelOrch(DBConnector *statedb, DBConnector *db, const st
     m_tunnelNameTable = unique_ptr<Table>(new Table(m_counter_db.get(), COUNTERS_TUNNEL_NAME_MAP));
     m_tunnelTypeTable = unique_ptr<Table>(new Table(m_counter_db.get(), COUNTERS_TUNNEL_TYPE_MAP));
 
-    m_vidToRidTable = unique_ptr<Table>(new Table(m_asic_db.get(), "VIDTORID"));
+    if (gTraditionalFlexCounter)
+    {
+        m_vidToRidTable = unique_ptr<Table>(new Table(m_asic_db.get(), "VIDTORID"));
+    }
 
     auto intervT = timespec { .tv_sec = FLEX_COUNTER_UPD_INTERVAL , .tv_nsec = 0 };
     m_FlexCounterUpdTimer = new SelectableTimer(intervT);

--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -30,6 +30,7 @@ extern Directory<Orch*> gDirectory;
 extern PortsOrch*       gPortsOrch;
 extern sai_object_id_t  gUnderlayIfId;
 extern FlexManagerDirectory g_FlexManagerDirectory;
+extern bool gTraditionalFlexCounter;
 
 #define FLEX_COUNTER_UPD_INTERVAL 1
 
@@ -1237,7 +1238,7 @@ void VxlanTunnelOrch::doTask(SelectableTimer &timer)
         string value;
         const auto id = sai_serialize_object_id(it->first);
 
-        if (m_vidToRidTable->hget("", id, value))
+        if (!gTraditionalFlexCounter || m_vidToRidTable->hget("", id, value))
         {
             SWSS_LOG_INFO("Registering %s, id %s", it->second.c_str(), id.c_str());
             vector<FieldValueTuple> tunnelNameFvs;

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -58,6 +58,7 @@ tests_SOURCES = aclorch_ut.cpp \
                 test_failure_handling.cpp \
                 warmrestarthelper_ut.cpp \
                 neighorch_ut.cpp \
+                flexcounter_ut.cpp \
                 $(top_srcdir)/warmrestart/warmRestartHelper.cpp \
                 $(top_srcdir)/lib/gearboxutils.cpp \
                 $(top_srcdir)/lib/subintf.cpp \

--- a/tests/mock_tests/bufferorch_ut.cpp
+++ b/tests/mock_tests/bufferorch_ut.cpp
@@ -378,6 +378,9 @@ namespace bufferorch_test
             delete gCrmOrch;
             gCrmOrch = nullptr;
 
+            delete gBufferOrch;
+            gBufferOrch = nullptr;
+
             delete gSwitchOrch;
             gSwitchOrch = nullptr;
 

--- a/tests/mock_tests/flexcounter_ut.cpp
+++ b/tests/mock_tests/flexcounter_ut.cpp
@@ -1,0 +1,618 @@
+#define private public // make Directory::m_values available to clean it.
+#include "directory.h"
+#undef private
+
+#include "json.h"
+#include "ut_helper.h"
+#include "mock_orchagent_main.h"
+#include "mock_table.h"
+#include "notifier.h"
+#define private public
+#include "pfcactionhandler.h"
+#include "switchorch.h"
+#include <sys/mman.h>
+#undef private
+#define private public
+#include "warm_restart.h"
+#undef private
+
+#include <sstream>
+
+extern redisReply *mockReply;
+
+#define QUEUE_WATERMARK_FLEX_STAT_COUNTER_POLL_MSECS "60000"
+#define PG_WATERMARK_FLEX_STAT_COUNTER_POLL_MSECS    "60000"
+#define PG_DROP_FLEX_STAT_COUNTER_POLL_MSECS         "10000"
+#define PORT_RATE_FLEX_COUNTER_POLLING_INTERVAL_MS   "1000"
+
+namespace flexcounter_test
+{
+    using namespace std;
+
+    // SAI default ports
+    std::map<std::string, std::vector<swss::FieldValueTuple>> defaultPortList;
+
+    shared_ptr<swss::DBConnector> mockFlexCounterDb;
+    shared_ptr<swss::Table> mockFlexCounterGroupTable;
+    shared_ptr<swss::Table> mockFlexCounterTable;
+    sai_set_switch_attribute_fn mockOldSaiSetSwitchAttribute;
+
+    void mock_counter_init(sai_set_switch_attribute_fn old)
+    {
+        mockFlexCounterDb = make_shared<swss::DBConnector>("FLEX_COUNTER_DB", 0);
+        mockFlexCounterGroupTable = make_shared<swss::Table>(mockFlexCounterDb.get(), "FLEX_COUNTER_GROUP_TABLE");
+        mockFlexCounterTable = make_shared<swss::Table>(mockFlexCounterDb.get(), "FLEX_COUNTER_TABLE");
+
+        mockOldSaiSetSwitchAttribute = old;
+    }
+
+    sai_status_t mockFlexCounterOperation(sai_object_id_t objectId, const sai_attribute_t *attr)
+    {
+        auto *param = reinterpret_cast<sai_redis_flex_counter_parameter_t*>(attr->value.ptr);
+        std::vector<swss::FieldValueTuple> entries;
+        auto serializedObjectId = sai_serialize_object_id(objectId);
+        std::string key(param->counter_key);
+
+        if (param->stats_mode != nullptr)
+        {
+            entries.push_back({STATS_MODE_FIELD, param->stats_mode});
+        }
+
+        if (param->counter_ids != nullptr)
+        {
+            entries.push_back({param->counter_field_name, param->counter_ids});
+            mockFlexCounterTable->set(key, entries);
+        }
+        else
+        {
+            mockFlexCounterTable->del(key);
+        }
+
+        return 0;
+    }
+
+    sai_status_t mockFlexCounterGroupOperation(sai_object_id_t objectId, const sai_attribute_t *attr)
+    {
+        std::vector<swss::FieldValueTuple> entries;
+        sai_redis_flex_counter_group_parameter_t *flexCounterGroupParam = reinterpret_cast<sai_redis_flex_counter_group_parameter_t*>(attr->value.ptr);
+
+        std::string key(flexCounterGroupParam->counter_group_name);
+
+        if (flexCounterGroupParam->poll_interval != nullptr)
+        {
+            entries.push_back({POLL_INTERVAL_FIELD, flexCounterGroupParam->poll_interval});
+        }
+
+        if (flexCounterGroupParam->stats_mode != nullptr)
+        {
+            entries.push_back({STATS_MODE_FIELD, flexCounterGroupParam->stats_mode});
+        }
+
+        if (flexCounterGroupParam->plugins != nullptr && flexCounterGroupParam->plugin_name != nullptr)
+        {
+            entries.push_back({flexCounterGroupParam->plugin_name, flexCounterGroupParam->plugins});
+        }
+
+        if (flexCounterGroupParam->operation != nullptr)
+        {
+            entries.push_back({FLEX_COUNTER_STATUS_FIELD, flexCounterGroupParam->operation});
+        }
+
+        mockFlexCounterGroupTable->set(key, entries);
+
+        return 0;
+    }
+
+    bool _checkFlexCounterTableContent(std::shared_ptr<swss::Table> table, std::string key, std::vector<swss::FieldValueTuple> entries)
+    {
+        vector<FieldValueTuple> fieldValues;
+        if (table->get(key, fieldValues))
+        {
+            set<FieldValueTuple> fvSet(fieldValues.begin(), fieldValues.end());
+            set<FieldValueTuple> expectedSet(entries.begin(), entries.end());
+
+            return (fvSet == expectedSet);
+        }
+
+        return false;
+    }
+
+    bool checkFlexCounterGroup(std::string group, std::vector<swss::FieldValueTuple> entries)
+    {
+        return _checkFlexCounterTableContent(mockFlexCounterGroupTable, group, entries);
+    }
+
+    bool checkFlexCounter(std::string group, sai_object_id_t oid, std::string counter_field_name, std::string mode="")
+    {
+        std::vector<swss::FieldValueTuple> entries;
+
+        if (!mockFlexCounterTable->get(group + ":" + sai_serialize_object_id(oid), entries))
+        {
+            return false;
+        }
+
+        if (fvField(entries[0]) == counter_field_name)
+        {
+            if (mode == "")
+            {
+                return true;
+            }
+            else
+            {
+                return (fvField(entries[1]) == "mode") && (fvValue(entries[1]) == mode);
+            }
+        }
+        else if (mode != "")
+        {
+            return (fvField(entries[1]) == counter_field_name) && (fvField(entries[0]) == "mode") && (fvValue(entries[0]) == mode);
+        }
+
+        return false;
+    }
+
+    bool checkFlexCounter(std::string group, sai_object_id_t oid, std::vector<swss::FieldValueTuple> entries)
+    {
+        return _checkFlexCounterTableContent(mockFlexCounterTable, group + ":" + sai_serialize_object_id(oid), entries);
+    }
+
+    sai_switch_api_t ut_sai_switch_api;
+    sai_switch_api_t *pold_sai_switch_api;
+
+    sai_status_t _ut_stub_sai_set_switch_attribute(
+        _In_ sai_object_id_t switch_id,
+        _In_ const sai_attribute_t *attr)
+    {
+        if (attr[0].id == SAI_REDIS_SWITCH_ATTR_FLEX_COUNTER_GROUP)
+        {
+            mockFlexCounterGroupOperation(switch_id, attr);
+        }
+        else if (attr[0].id == SAI_REDIS_SWITCH_ATTR_FLEX_COUNTER)
+        {
+            mockFlexCounterOperation(switch_id, attr);
+        }
+        return pold_sai_switch_api->set_switch_attribute(switch_id, attr);
+    }
+
+    void _hook_sai_switch_api()
+    {
+        ut_sai_switch_api = *sai_switch_api;
+        pold_sai_switch_api = sai_switch_api;
+        ut_sai_switch_api.set_switch_attribute = _ut_stub_sai_set_switch_attribute;
+        sai_switch_api = &ut_sai_switch_api;
+        mock_counter_init(nullptr);
+    }
+
+    void _unhook_sai_switch_api()
+    {
+        sai_switch_api = pold_sai_switch_api;
+    }
+
+    struct FlexCounterTest : public ::testing::Test
+    {
+        shared_ptr<swss::DBConnector> m_app_db;
+        shared_ptr<swss::DBConnector> m_config_db;
+        shared_ptr<swss::DBConnector> m_state_db;
+        shared_ptr<swss::DBConnector> m_counters_db;
+        shared_ptr<swss::DBConnector> m_chassis_app_db;
+        shared_ptr<swss::DBConnector> m_asic_db;
+        shared_ptr<swss::DBConnector> m_flex_counter_db;
+
+        FlexCounterTest()
+        {
+            // FIXME: move out from constructor
+            m_app_db = make_shared<swss::DBConnector>(
+                "APPL_DB", 0);
+            m_counters_db = make_shared<swss::DBConnector>(
+                "COUNTERS_DB", 0);
+            m_config_db = make_shared<swss::DBConnector>(
+                "CONFIG_DB", 0);
+            m_state_db = make_shared<swss::DBConnector>(
+                "STATE_DB", 0);
+            m_chassis_app_db = make_shared<swss::DBConnector>(
+                "CHASSIS_APP_DB", 0);
+            m_asic_db = make_shared<swss::DBConnector>(
+                "ASIC_DB", 0);
+            m_flex_counter_db = make_shared<swss::DBConnector>(
+                "FLEX_COUNTER_DB", 0);
+        }
+
+        virtual void SetUp() override
+        {
+            ::testing_db::reset();
+
+            gTraditionalFlexCounter = false;
+
+            _hook_sai_switch_api();
+
+            // Create dependencies ...
+            TableConnector stateDbSwitchTable(m_state_db.get(), "SWITCH_CAPABILITY");
+            TableConnector app_switch_table(m_app_db.get(), APP_SWITCH_TABLE_NAME);
+            TableConnector conf_asic_sensors(m_config_db.get(), CFG_ASIC_SENSORS_TABLE_NAME);
+
+            vector<TableConnector> switch_tables = {
+                conf_asic_sensors,
+                app_switch_table
+            };
+
+            ASSERT_EQ(gSwitchOrch, nullptr);
+            gSwitchOrch = new SwitchOrch(m_app_db.get(), switch_tables, stateDbSwitchTable);
+
+            const int portsorch_base_pri = 40;
+
+            vector<table_name_with_pri_t> ports_tables = {
+                { APP_PORT_TABLE_NAME, portsorch_base_pri + 5 },
+                { APP_SEND_TO_INGRESS_PORT_TABLE_NAME, portsorch_base_pri + 5 },
+                { APP_VLAN_TABLE_NAME, portsorch_base_pri + 2 },
+                { APP_VLAN_MEMBER_TABLE_NAME, portsorch_base_pri },
+                { APP_LAG_TABLE_NAME, portsorch_base_pri + 4 },
+                { APP_LAG_MEMBER_TABLE_NAME, portsorch_base_pri }
+            };
+
+            ASSERT_EQ(gPortsOrch, nullptr);
+
+            gPortsOrch = new PortsOrch(m_app_db.get(), m_state_db.get(), ports_tables, m_chassis_app_db.get());
+
+            vector<string> flex_counter_tables = {
+                CFG_FLEX_COUNTER_TABLE_NAME
+            };
+            auto* flexCounterOrch = new FlexCounterOrch(m_config_db.get(), flex_counter_tables);
+            gDirectory.set(flexCounterOrch);
+
+            vector<string> buffer_tables = { APP_BUFFER_POOL_TABLE_NAME,
+                                             APP_BUFFER_PROFILE_TABLE_NAME,
+                                             APP_BUFFER_QUEUE_TABLE_NAME,
+                                             APP_BUFFER_PG_TABLE_NAME,
+                                             APP_BUFFER_PORT_INGRESS_PROFILE_LIST_NAME,
+                                             APP_BUFFER_PORT_EGRESS_PROFILE_LIST_NAME };
+
+            ASSERT_EQ(gBufferOrch, nullptr);
+            gBufferOrch = new BufferOrch(m_app_db.get(), m_config_db.get(), m_state_db.get(), buffer_tables);
+
+            Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+
+            // Get SAI default ports to populate DB
+            auto ports = ut_helper::getInitialSaiPorts();
+
+            // Populate pot table with SAI ports
+            for (const auto &it : ports)
+            {
+                portTable.set(it.first, it.second);
+            }
+
+            // Set PortConfigDone
+            portTable.set("PortConfigDone", { { "count", to_string(ports.size()) } });
+            gPortsOrch->addExistingData(&portTable);
+            static_cast<Orch *>(gPortsOrch)->doTask();
+
+            portTable.set("PortInitDone", { { "lanes", "0" } });
+            gPortsOrch->addExistingData(&portTable);
+            static_cast<Orch *>(gPortsOrch)->doTask();
+
+            ASSERT_EQ(gIntfsOrch, nullptr);
+            gIntfsOrch = new IntfsOrch(m_app_db.get(), APP_INTF_TABLE_NAME, gVrfOrch, m_chassis_app_db.get());
+        }
+
+        virtual void TearDown() override
+        {
+            ::testing_db::reset();
+
+            auto buffer_maps = BufferOrch::m_buffer_type_maps;
+            for (auto &i : buffer_maps)
+            {
+                i.second->clear();
+            }
+
+            delete gNeighOrch;
+            gNeighOrch = nullptr;
+            delete gFdbOrch;
+            gFdbOrch = nullptr;
+            delete gIntfsOrch;
+            gIntfsOrch = nullptr;
+            delete gPortsOrch;
+            gPortsOrch = nullptr;
+            delete gBufferOrch;
+            gBufferOrch = nullptr;
+            delete gPfcwdOrch<PfcWdDlrHandler, PfcWdDlrHandler>;
+            gPfcwdOrch<PfcWdDlrHandler, PfcWdDlrHandler> = nullptr;
+            delete gQosOrch;
+            gQosOrch = nullptr;
+            delete gSwitchOrch;
+            gSwitchOrch = nullptr;
+
+            // clear orchs saved in directory
+            gDirectory.m_values.clear();
+
+            _unhook_sai_switch_api();
+        }
+
+        static void SetUpTestCase()
+        {
+            // Init switch and create dependencies
+
+            map<string, string> profile = {
+                { "SAI_VS_SWITCH_TYPE", "SAI_VS_SWITCH_TYPE_BCM56850" },
+                { "KV_DEVICE_MAC_ADDRESS", "20:03:04:05:06:00" }
+            };
+
+            auto status = ut_helper::initSaiApi(profile);
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+            sai_attribute_t attr;
+
+            attr.id = SAI_SWITCH_ATTR_INIT_SWITCH;
+            attr.value.booldata = true;
+
+            status = sai_switch_api->create_switch(&gSwitchId, 1, &attr);
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+            // Get switch source MAC address
+            attr.id = SAI_SWITCH_ATTR_SRC_MAC_ADDRESS;
+            status = sai_switch_api->get_switch_attribute(gSwitchId, 1, &attr);
+
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+            gMacAddress = attr.value.mac;
+
+            // Get the default virtual router ID
+            attr.id = SAI_SWITCH_ATTR_DEFAULT_VIRTUAL_ROUTER_ID;
+            status = sai_switch_api->get_switch_attribute(gSwitchId, 1, &attr);
+
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+            gVirtualRouterId = attr.value.oid;
+
+            // Get SAI default ports
+            defaultPortList = ut_helper::getInitialSaiPorts();
+            ASSERT_TRUE(!defaultPortList.empty());
+        }
+
+        static void TearDownTestCase()
+        {
+            auto status = sai_switch_api->remove_switch(gSwitchId);
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+            gSwitchId = 0;
+
+            ut_helper::uninitSaiApi();
+        }
+
+    };
+
+    TEST_F(FlexCounterTest, CounterTest)
+    {
+        // Check flex counter database
+        ASSERT_TRUE(checkFlexCounterGroup(QUEUE_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP,
+                                          {
+                                              {STATS_MODE_FIELD, STATS_MODE_READ_AND_CLEAR},
+                                              {POLL_INTERVAL_FIELD, QUEUE_WATERMARK_FLEX_STAT_COUNTER_POLL_MSECS},
+                                              {QUEUE_PLUGIN_FIELD, ""}
+                                          }));
+        ASSERT_TRUE(checkFlexCounterGroup(PG_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP,
+                                          {
+                                              {STATS_MODE_FIELD, STATS_MODE_READ_AND_CLEAR},
+                                              {POLL_INTERVAL_FIELD, PG_WATERMARK_FLEX_STAT_COUNTER_POLL_MSECS},
+                                              {PG_PLUGIN_FIELD, ""}
+                                          }));
+        ASSERT_TRUE(checkFlexCounterGroup(PORT_STAT_COUNTER_FLEX_COUNTER_GROUP,
+                                          {
+                                              {STATS_MODE_FIELD, STATS_MODE_READ},
+                                              {POLL_INTERVAL_FIELD, PORT_RATE_FLEX_COUNTER_POLLING_INTERVAL_MS},
+                                              {PORT_PLUGIN_FIELD, ""},
+                                              {"FLEX_COUNTER_STATUS", "disable"}
+                                          }));
+        ASSERT_TRUE(checkFlexCounterGroup(PG_DROP_STAT_COUNTER_FLEX_COUNTER_GROUP,
+                                          {
+                                              {STATS_MODE_FIELD, STATS_MODE_READ},
+                                              {POLL_INTERVAL_FIELD, PG_DROP_FLEX_STAT_COUNTER_POLL_MSECS}
+                                          }));
+        ASSERT_TRUE(checkFlexCounterGroup(RIF_STAT_COUNTER_FLEX_COUNTER_GROUP,
+                                          {
+                                              {STATS_MODE_FIELD, STATS_MODE_READ},
+                                              {POLL_INTERVAL_FIELD, "1000"},
+                                          }));
+
+        Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+        Table sendToIngressPortTable = Table(m_app_db.get(), APP_SEND_TO_INGRESS_PORT_TABLE_NAME);
+        Table pgTable = Table(m_app_db.get(), APP_BUFFER_PG_TABLE_NAME);
+        Table pgTableCfg = Table(m_config_db.get(), CFG_BUFFER_PG_TABLE_NAME);
+        Table profileTable = Table(m_app_db.get(), APP_BUFFER_PROFILE_TABLE_NAME);
+        Table poolTable = Table(m_app_db.get(), APP_BUFFER_POOL_TABLE_NAME);
+        Table flexCounterCfg = Table(m_config_db.get(), CFG_FLEX_COUNTER_TABLE_NAME);
+
+        // Get SAI default ports to populate DB
+        auto ports = ut_helper::getInitialSaiPorts();
+
+        // Create test buffer pool
+        poolTable.set(
+            "test_pool",
+            {
+                { "type", "ingress" },
+                { "mode", "dynamic" },
+                { "size", "4200000" },
+            });
+
+        // Create test buffer profile
+        profileTable.set("test_profile", { { "pool", "test_pool" },
+                                           { "xon", "14832" },
+                                           { "xoff", "14832" },
+                                           { "size", "35000" },
+                                           { "dynamic_th", "0" } });
+
+        // Apply profile on PGs 3-4 all ports
+        for (const auto &it : ports)
+        {
+            std::ostringstream ossAppl, ossCfg;
+            ossAppl << it.first << ":3-4";
+            pgTable.set(ossAppl.str(), { { "profile", "test_profile" } });
+            ossCfg << it.first << "|3-4";
+            pgTableCfg.set(ossCfg.str(), { { "profile", "test_profile" } });
+        }
+
+        // Populate pot table with SAI ports
+        for (const auto &it : ports)
+        {
+            portTable.set(it.first, it.second);
+        }
+
+        // Set PortConfigDone
+        portTable.set("PortConfigDone", { { "count", to_string(ports.size()) } });
+        // Populate send to ingresss port table
+        sendToIngressPortTable.set("SEND_TO_INGRESS", {{"NULL", "NULL"}});
+
+        // refill consumer
+        gPortsOrch->addExistingData(&portTable);
+        gBufferOrch->addExistingData(&pgTable);
+        gBufferOrch->addExistingData(&poolTable);
+        gBufferOrch->addExistingData(&profileTable);
+
+        // Apply configuration :
+        //  create ports
+        static_cast<Orch *>(gBufferOrch)->doTask();
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        portTable.set("PortInitDone", { { "lanes", "0" } });
+        gPortsOrch->addExistingData(&portTable);
+
+        // Apply configuration
+        //  configure buffers
+        //          ports
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        // Since init done is set now, apply buffers
+        static_cast<Orch *>(gBufferOrch)->doTask();
+
+        ASSERT_TRUE(gPortsOrch->allPortsReady());
+
+        // Enable and check counters
+        const std::vector<FieldValueTuple> values({ {"FLEX_COUNTER_DELAY_STATUS", "false"},
+                                                    {"FLEX_COUNTER_STATUS", "enable"} });
+        flexCounterCfg.set("PG_WATERMARK", values);
+        flexCounterCfg.set("QUEUE_WATERMARK", values);
+        flexCounterCfg.set("QUEUE", values);
+        flexCounterCfg.set("PORT_BUFFER_DROP", values);
+        flexCounterCfg.set("PG_DROP", values);
+        flexCounterCfg.set("PORT", values);
+        flexCounterCfg.set("BUFFER_POOL_WATERMARK", values);
+
+        auto flexCounterOrch = gDirectory.get<FlexCounterOrch*>();
+        flexCounterOrch->addExistingData(&flexCounterCfg);
+        static_cast<Orch *>(flexCounterOrch)->doTask();
+
+        ASSERT_TRUE(checkFlexCounterGroup("BUFFER_POOL_WATERMARK_STAT_COUNTER",
+                                          {
+                                              {"POLL_INTERVAL", "60000"},
+                                              {"STATS_MODE", "STATS_MODE_READ_AND_CLEAR"},
+                                              {"FLEX_COUNTER_STATUS", "enable"},
+                                              {"BUFFER_POOL_PLUGIN_LIST", ""}
+                                          }));
+        ASSERT_TRUE(checkFlexCounterGroup("QUEUE_WATERMARK_STAT_COUNTER",
+                                          {
+                                              {"POLL_INTERVAL", "60000"},
+                                              {"STATS_MODE", "STATS_MODE_READ_AND_CLEAR"},
+                                              {"FLEX_COUNTER_STATUS", "enable"},
+                                              {"QUEUE_PLUGIN_LIST", ""}
+                                          }));
+        ASSERT_TRUE(checkFlexCounterGroup("PG_WATERMARK_STAT_COUNTER",
+                                          {
+                                              {"POLL_INTERVAL", "60000"},
+                                              {"STATS_MODE", "STATS_MODE_READ_AND_CLEAR"},
+                                              {"FLEX_COUNTER_STATUS", "enable"},
+                                              {"PG_PLUGIN_LIST", ""}
+                                          }));
+        ASSERT_TRUE(checkFlexCounterGroup("PORT_BUFFER_DROP_STAT",
+                                          {
+                                              {"POLL_INTERVAL", "60000"},
+                                              {"STATS_MODE", "STATS_MODE_READ"},
+                                              {"FLEX_COUNTER_STATUS", "enable"}
+                                          }));
+        ASSERT_TRUE(checkFlexCounterGroup("PG_DROP_STAT_COUNTER",
+                                          {
+                                              {"POLL_INTERVAL", "10000"},
+                                              {"STATS_MODE", "STATS_MODE_READ"},
+                                              {"FLEX_COUNTER_STATUS", "enable"}
+                                          }));
+        ASSERT_TRUE(checkFlexCounterGroup("PORT_STAT_COUNTER",
+                                          {
+                                              {"POLL_INTERVAL", "1000"},
+                                              {"STATS_MODE", "STATS_MODE_READ"},
+                                              {"FLEX_COUNTER_STATUS", "enable"},
+                                              {"PORT_PLUGIN_LIST", ""}
+                                          }));
+        ASSERT_TRUE(checkFlexCounterGroup("QUEUE_STAT_COUNTER",
+                                          {
+                                              {"POLL_INTERVAL", "10000"},
+                                              {"STATS_MODE", "STATS_MODE_READ"},
+                                              {"FLEX_COUNTER_STATUS", "enable"},
+                                          }));
+
+        sai_object_id_t oid;
+        oid = (*BufferOrch::m_buffer_type_maps[APP_BUFFER_POOL_TABLE_NAME])["test_pool"].m_saiObjectId;
+        ASSERT_TRUE(checkFlexCounter("BUFFER_POOL_WATERMARK_STAT_COUNTER", oid, "BUFFER_POOL_COUNTER_ID_LIST"));
+        Port port;
+        gPortsOrch->getPort(ports.begin()->first, port);
+        oid = port.m_priority_group_ids[3];
+        ASSERT_TRUE(checkFlexCounter("PG_DROP_STAT_COUNTER", oid,
+                                     {
+                                         {"PG_COUNTER_ID_LIST",
+                                          "SAI_INGRESS_PRIORITY_GROUP_STAT_DROPPED_PACKETS"
+                                         }
+                                     }));
+        ASSERT_TRUE(checkFlexCounter("PG_WATERMARK_STAT_COUNTER", oid,
+                                     {
+                                         {"PG_COUNTER_ID_LIST",
+                                          "SAI_INGRESS_PRIORITY_GROUP_STAT_XOFF_ROOM_WATERMARK_BYTES,"
+                                          "SAI_INGRESS_PRIORITY_GROUP_STAT_SHARED_WATERMARK_BYTES"
+                                         }
+                                     }));
+        oid = port.m_queue_ids[3];
+        ASSERT_TRUE(checkFlexCounter("QUEUE_WATERMARK_STAT_COUNTER", oid,
+                                     {
+                                         {"QUEUE_COUNTER_ID_LIST",
+                                          "SAI_QUEUE_STAT_SHARED_WATERMARK_BYTES"
+                                         }
+                                     }));
+        ASSERT_TRUE(checkFlexCounter("QUEUE_STAT_COUNTER", oid,
+                                     {
+                                         {"QUEUE_COUNTER_ID_LIST",
+                                          "SAI_QUEUE_STAT_DROPPED_BYTES,SAI_QUEUE_STAT_DROPPED_PACKETS,"
+                                          "SAI_QUEUE_STAT_BYTES,SAI_QUEUE_STAT_PACKETS"
+                                         }
+                                     }));
+        oid = port.m_port_id;
+        ASSERT_TRUE(checkFlexCounter("PORT_BUFFER_DROP_STAT", oid,
+                                     {
+                                         {"PORT_COUNTER_ID_LIST",
+                                          "SAI_PORT_STAT_OUT_DROPPED_PKTS,SAI_PORT_STAT_IN_DROPPED_PKTS"
+                                         }
+                                     }));
+        // Do not check the content of port counter since it's large and varies among platforms.
+        ASSERT_TRUE(checkFlexCounter("PORT_STAT_COUNTER", oid, "PORT_COUNTER_ID_LIST"));
+
+        // create a routing interface
+        std::deque<KeyOpFieldsValuesTuple> entries;
+        entries.push_back({"Ethernet0", "SET", { {"mtu", "9100"}}});
+        auto consumer = dynamic_cast<Consumer *>(gIntfsOrch->getExecutor(APP_INTF_TABLE_NAME));
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gIntfsOrch)->doTask();
+
+        // Check flex counter database
+        auto rifOid = gIntfsOrch->m_rifsToAdd[0].m_rif_id;
+        (gIntfsOrch)->doTask(*gIntfsOrch->m_updateMapsTimer);
+        ASSERT_TRUE(checkFlexCounter(RIF_STAT_COUNTER_FLEX_COUNTER_GROUP, rifOid,
+                                     {
+                                         {RIF_COUNTER_ID_LIST,
+                                          "SAI_ROUTER_INTERFACE_STAT_IN_PACKETS,SAI_ROUTER_INTERFACE_STAT_IN_OCTETS,"
+                                          "SAI_ROUTER_INTERFACE_STAT_IN_ERROR_PACKETS,SAI_ROUTER_INTERFACE_STAT_IN_ERROR_OCTETS,"
+                                          "SAI_ROUTER_INTERFACE_STAT_OUT_PACKETS,SAI_ROUTER_INTERFACE_STAT_OUT_OCTETS,"
+                                          "SAI_ROUTER_INTERFACE_STAT_OUT_ERROR_PACKETS,SAI_ROUTER_INTERFACE_STAT_OUT_ERROR_OCTETS,"
+                                         }
+                                     }));
+
+        // remove the dependency, expect delete and create a new one
+        entries.clear();
+        entries.push_back({"Ethernet0", "DEL", { {} }});
+        static_cast<Orch *>(gIntfsOrch)->doTask();
+
+        // Check flex counter database
+        ASSERT_TRUE(!checkFlexCounter(RIF_STAT_COUNTER_FLEX_COUNTER_GROUP, rifOid, RIF_COUNTER_ID_LIST));
+    }
+}

--- a/tests/mock_tests/mock_orch_test.h
+++ b/tests/mock_tests/mock_orch_test.h
@@ -193,6 +193,7 @@ namespace mock_orch_test
                 APP_BUFFER_PORT_EGRESS_PROFILE_LIST_NAME
             };
             gBufferOrch = new BufferOrch(m_app_db.get(), m_config_db.get(), m_state_db.get(), buffer_tables);
+            ut_orch_list.push_back((Orch **)&gBufferOrch);
 
             TableConnector stateDbSwitchTable(m_state_db.get(), STATE_SWITCH_CAPABILITY_TABLE_NAME);
             TableConnector app_switch_table(m_app_db.get(), APP_SWITCH_TABLE_NAME);

--- a/tests/mock_tests/mock_orchagent_main.cpp
+++ b/tests/mock_tests/mock_orchagent_main.cpp
@@ -16,6 +16,7 @@ string gMySwitchType = "switch";
 int32_t gVoqMySwitchId = 0;
 string gMyHostName = "Linecard1";
 string gMyAsicName = "Asic0";
+bool gTraditionalFlexCounter = false;
 
 VRFOrch *gVrfOrch;
 

--- a/tests/mock_tests/mock_orchagent_main.cpp
+++ b/tests/mock_tests/mock_orchagent_main.cpp
@@ -16,7 +16,7 @@ string gMySwitchType = "switch";
 int32_t gVoqMySwitchId = 0;
 string gMyHostName = "Linecard1";
 string gMyAsicName = "Asic0";
-bool gTraditionalFlexCounter = true;
+bool gTraditionalFlexCounter = false;
 
 VRFOrch *gVrfOrch;
 

--- a/tests/mock_tests/mock_orchagent_main.cpp
+++ b/tests/mock_tests/mock_orchagent_main.cpp
@@ -16,7 +16,7 @@ string gMySwitchType = "switch";
 int32_t gVoqMySwitchId = 0;
 string gMyHostName = "Linecard1";
 string gMyAsicName = "Asic0";
-bool gTraditionalFlexCounter = false;
+bool gTraditionalFlexCounter = true;
 
 VRFOrch *gVrfOrch;
 

--- a/tests/mock_tests/mock_table.cpp
+++ b/tests/mock_tests/mock_table.cpp
@@ -1,6 +1,7 @@
 #include "table.h"
 #include "producerstatetable.h"
 #include <set>
+#include <memory>
 
 using TableDataT = std::map<std::string, std::vector<swss::FieldValueTuple>>;
 using TablesT = std::map<std::string, TableDataT>;
@@ -23,21 +24,29 @@ namespace swss
 
     using namespace testing_db;
 
-    bool Table::get(const std::string &key, std::vector<FieldValueTuple> &ovalues)
+    void merge_values(std::vector<FieldValueTuple> &existing_values, const std::vector<FieldValueTuple> &values)
     {
-        auto table = gDB[m_pipe->getDbId()][getTableName()];
-        if (table.find(key) == table.end())
+        std::vector<FieldValueTuple> new_values(values);
+        std::set<std::string> field_set;
+        for (auto &value : values)
         {
-            return false;
+            field_set.insert(fvField(value));
         }
-
-        ovalues = table[key];
-        return true;
+        for (auto &value : existing_values)
+        {
+            auto &field = fvField(value);
+            if (field_set.find(field) != field_set.end())
+            {
+                continue;
+            }
+            new_values.push_back(value);
+        }
+        existing_values.swap(new_values);
     }
 
-    bool Table::hget(const std::string &key, const std::string &field, std::string &value)
+    bool _hget(int dbId, const std::string &tableName, const std::string &key, const std::string &field, std::string &value)
     {
-        auto table = gDB[m_pipe->getDbId()][getTableName()];
+        auto table = gDB[dbId][tableName];
         if (table.find(key) == table.end())
         {
             return false;
@@ -53,6 +62,23 @@ namespace swss
         }
 
         return false;
+    }
+
+    bool Table::get(const std::string &key, std::vector<FieldValueTuple> &ovalues)
+    {
+        auto table = gDB[m_pipe->getDbId()][getTableName()];
+        if (table.find(key) == table.end())
+        {
+            return false;
+        }
+
+        ovalues = table[key];
+        return true;
+    }
+
+    bool Table::hget(const std::string &key, const std::string &field, std::string &value)
+    {
+        return _hget(m_pipe->getDbId(), getTableName(), key, field, value);
     }
 
     void Table::set(const std::string &key,
@@ -120,5 +146,19 @@ namespace swss
     {
         auto &table = gDB[m_pipe->getDbId()][getTableName()];
         table.erase(key);
+    }
+
+    std::shared_ptr<std::string> DBConnector::hget(const std::string &key, const std::string &field)
+    {
+        std::string value;
+        if (_hget(getDbId(), key, "", field, value))
+        {
+            std::shared_ptr<std::string> ptr(new std::string(value));
+            return ptr;
+        }
+        else
+        {
+            return std::shared_ptr<std::string>(NULL);
+        }
     }
 }

--- a/tests/mock_tests/mock_table.cpp
+++ b/tests/mock_tests/mock_table.cpp
@@ -87,7 +87,15 @@ namespace swss
                     const std::string &prefix)
     {
         auto &table = gDB[m_pipe->getDbId()][getTableName()];
-        table[key] = values;
+        auto iter = table.find(key);
+        if (iter == table.end())
+        {
+            table[key] = values;
+        }
+        else
+        {
+            merge_values(iter->second, values);
+        }
     }
 
     void Table::getKeys(std::vector<std::string> &keys)
@@ -121,22 +129,7 @@ namespace swss
         }
         else
         {
-            std::vector<FieldValueTuple> new_values(values);
-            std::set<std::string> field_set;
-            for (auto &value : values)
-            {
-                field_set.insert(fvField(value));
-            }
-            for (auto &value : iter->second)
-            {
-                auto &field = fvField(value);
-                if (field_set.find(field) != field_set.end())
-                {
-                    continue;
-                }
-                new_values.push_back(value);
-            }
-            iter->second.swap(new_values);
+            merge_values(iter->second, values);
         }
     }
 

--- a/tests/mock_tests/qosorch_ut.cpp
+++ b/tests/mock_tests/qosorch_ut.cpp
@@ -605,6 +605,9 @@ namespace qosorch_test
             delete gQosOrch;
             gQosOrch = nullptr;
 
+            delete gBufferOrch;
+            gBufferOrch = nullptr;
+
             delete tunnel_decap_orch;
             tunnel_decap_orch = nullptr;
 

--- a/tests/mock_tests/routeorch_ut.cpp
+++ b/tests/mock_tests/routeorch_ut.cpp
@@ -356,6 +356,9 @@ namespace routeorch_test
             delete gPortsOrch;
             gPortsOrch = nullptr;
 
+            delete gBufferOrch;
+            gBufferOrch = nullptr;
+
             sai_route_api = pold_sai_route_api;
             ut_helper::uninitSaiApi();
         }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Fix flow counter out-of-order issue by notifying counter operations using SelectableChannel

Signed-off-by: Stephen Sun <stephens@nvidia.com>

**Why I did it**

Currently, the operations of SAI objects and their counters (if any) are triggered by different channels, which introduces racing conditions:
- the creation and destruction of the objects are notified using the `SelectableChannel`,
- the operations of counters, including starting and stopping polling the counters, are notified by listening to the `FLEX_COUNTER` and `FLEX_COUNTER_GROUP` tables in the `FLEX_COUNTER_DB`
- The orchagent always respects the order when starting/stopping counter-polling (which means to start counter-polling after creating the object and to stop counter-polling before destroying the object) but `syncd` can receive events in a wrong order, eg. it receives destroying an object first and then stopping counter polling on the object, it can poll counter for a non-exist object, which causes errors in vendor SAI.

The new solution is to extend SAI redis attributes on the SAI_SWITCH_OBJECT to notify counter polling. As a result, all the objects and their counters are notified using a unified channel, the `SelectableChannel`.

**How I verified it**

Manual test
Regression test
Mock test

**Details if related**
1. Extend SAI redis attribute on the switch object to identify counter-polling operations.
2. Introduce a CLI option of orchagent to identify whether the new or the old approach is used for notifying counter-polling. It can not be changed on the fly.
3. Move the logic to notify counter polling from each orchagent class and flex counter manager class to a commonplace.    The logic is:
    - For the new approach, notify counter polling using SAI extended redis attribute
    - For the old approach, notify counter-polling using flex database tables. The corresponding flex database table objects (`ProducerTable`) are initialized during orchagent initialization, before any flex counter operations.
4. Remove the definition of and the references to flex counter and flex counter group table in each orchagent class (usually `m_flexCounterTable` and `m_flexCounterGroupTable`)
5. Improve the logic to load the counters' Lua plugin for mock test. The Lua scripts are not available in the mock test scenarios, which causes exceptions to load them in mock test. In case it fails to load the Lua plugin,
    - Originally, it skipped any flex counter group operations.
    - Now, it will leave the SHA code of the Lua plugin empty, and continue to notify the flex counter operations to SAI redis.
      - In the production scenario, where it can hardly happen, the plugin field will not be notified to SAI.
      - In the mock test scenario, it will notify SAI as it is. This is for mock test to verify whether the plugin field is provided as expected.
6. Gearbox counter handling.
    - Maintain a mapping from each OID created based on the gearbox, from the object ID itself to the gearbox's OID.
    - To notify counter operations for such OIDs in the new approach, we need to first fetch the corresponding gearbox OID from the mapping and the notify the gearbox OID as `switch OID`.
    - The old approach looks buggy.
      - There can be more than one gearbox syncd docker in the system, which is a P2MP scenario, the OA needs to communicate to multiple gearbox syncd dockers.
      - The old approach leverages `ConsumerTable`, `ProducerTable` mechanism to communicate between OA and sairedis. However, it works for P2P scenarios only. There is a logic for `ConsumerTable` to **consume** the update once a gearbox syncd sees it, leaving all rest gearbox syncd daemons to see nothing. As a result, for each update there is only one gearbox syncd that sees and handles it.

***Performance analysis***
The counter operations are handled in the same thread in both the new and old solutions.
In swss, the counter operation was asynchronous in the old solution and is synchronous now, which can introduce a bit more latency. However, as the number of counter operations is small, no performance degradation is observed.
