### PR TITLE
Do not apply QoS mapping object until it is resolved

### DIFF
--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -2018,6 +2018,7 @@ task_process_status QosOrch::handleGlobalQosMap(const string &OP, KeyOpFieldsVal
             {
                 SWSS_LOG_INFO("Global QoS map %s is not yet created", map_name.c_str());
                 task_status = task_process_status::task_need_retry;
+                continue;
             }
 
             if (applyDscpToTcMapToSwitch(SAI_SWITCH_ATTR_QOS_DSCP_TO_TC_MAP, id))

--- a/tests/mock_tests/qosorch_ut.cpp
+++ b/tests/mock_tests/qosorch_ut.cpp
@@ -1163,6 +1163,7 @@ namespace qosorch_test
         static_cast<Orch *>(gQosOrch)->doTask();
         // Check DSCP_TO_TC_MAP|AZURE is applied to switch
         ASSERT_EQ((*QosOrch::getTypeMap()[CFG_DSCP_TO_TC_MAP_TABLE_NAME])["AZURE"].m_saiObjectId, switch_dscp_to_tc_map_id);
+        CheckDependency(CFG_PORT_QOS_MAP_TABLE_NAME, "global", "dscp_to_tc_map", CFG_DSCP_TO_TC_MAP_TABLE_NAME, "AZURE");
 
         // Remove global DSCP_TO_TC_MAP
         entries.push_back({"global", "DEL", {}});
@@ -1185,7 +1186,37 @@ namespace qosorch_test
         // Check DSCP_TO_TC_MAP|AZURE is removed, and the switch_level dscp_to_tc_map is set to NULL
         ASSERT_EQ(current_sai_remove_qos_map_count + 1, sai_remove_qos_map_count);
         ASSERT_EQ((*QosOrch::getTypeMap()[CFG_DSCP_TO_TC_MAP_TABLE_NAME]).count("AZURE"), 0);
+
+        // Run the test in reverse order
+        entries.push_back({"global", "SET",
+                            {
+                                {"dscp_to_tc_map", "AZURE"}
+                            }});
+        consumer = dynamic_cast<Consumer *>(gQosOrch->getExecutor(CFG_PORT_QOS_MAP_TABLE_NAME));
+        consumer->addToSync(entries);
+        entries.clear();
+
+        // Try draining PORT_QOS_MAP table
+        static_cast<Orch *>(gQosOrch)->doTask();
+        // Check DSCP_TO_TC_MAP|AZURE is applied to switch
+        CheckDependency(CFG_PORT_QOS_MAP_TABLE_NAME, "global", "dscp_to_tc_map", CFG_DSCP_TO_TC_MAP_TABLE_NAME);
+        ASSERT_EQ((*QosOrch::getTypeMap()[CFG_DSCP_TO_TC_MAP_TABLE_NAME])["AZURE"].m_saiObjectId, switch_dscp_to_tc_map_id);
+
+        entries.push_back({"AZURE", "SET",
+                           {
+                               {"1", "0"},
+                               {"0", "1"}
+                           }});
+
+        consumer = dynamic_cast<Consumer *>(gQosOrch->getExecutor(CFG_DSCP_TO_TC_MAP_TABLE_NAME));
+        consumer->addToSync(entries);
+        entries.clear();
         
+        // Try draining DSCP_TO_TC_MAP and PORT_QOS_MAP table
+        static_cast<Orch *>(gQosOrch)->doTask();
+        // Check DSCP_TO_TC_MAP|AZURE is applied to switch
+        CheckDependency(CFG_PORT_QOS_MAP_TABLE_NAME, "global", "dscp_to_tc_map", CFG_DSCP_TO_TC_MAP_TABLE_NAME, "AZURE");
+        ASSERT_EQ((*QosOrch::getTypeMap()[CFG_DSCP_TO_TC_MAP_TABLE_NAME])["AZURE"].m_saiObjectId, switch_dscp_to_tc_map_id);
     }
 
     TEST_F(QosOrchTest, QosOrchTestRetryFirstItem)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Do not apply the global DSCP to TC map to the switch object until the mapping object has been created.

**Why I did it**

Fix issue: if orchagent handles tables in the following order, it will fail in step 1 and the configure will never applied.
1. PORT_QOS_MAP|global object
2. and then DSCP_TO_TC object

**How I verified it**

Mock and manual test

**Details if related**
