### PR TITLE
Create counter for the queue to which the host CPU traffic is sent

### DIFF
--- a/orchagent/flexcounterorch.cpp
+++ b/orchagent/flexcounterorch.cpp
@@ -400,6 +400,13 @@ map<string, FlexCounterQueueStates> FlexCounterOrch::getQueueConfigurations()
                 {
                     queuesStateVector.at(configPortName).enableQueueCounter(startIndex);
                 }
+
+                Port port;
+                gPortsOrch->getPort(configPortName, port);
+                if (port.m_host_tx_queue_configured && port.m_host_tx_queue <= maxQueueIndex)
+                {
+                    queuesStateVector.at(configPortName).enableQueueCounter(port.m_host_tx_queue);
+                }
             } catch (std::invalid_argument const& e) {
                     SWSS_LOG_ERROR("Invalid queue index [%s] for port [%s]", configPortQueues.c_str(), configPortName.c_str());
                     continue;

--- a/orchagent/p4orch/tests/fake_portorch.cpp
+++ b/orchagent/p4orch/tests/fake_portorch.cpp
@@ -189,11 +189,11 @@ void PortsOrch::generateQueueMapPerPort(const Port &port, FlexCounterQueueStates
 {
 }
 
-void PortsOrch::createPortBufferQueueCounters(const Port &port, string queues)
+void PortsOrch::createPortBufferQueueCounters(const Port &port, string queues, bool skip_host_tx_queue)
 {
 }
 
-void PortsOrch::removePortBufferQueueCounters(const Port &port, string queues)
+void PortsOrch::removePortBufferQueueCounters(const Port &port, string queues, bool skip_host_tx_queue)
 {
 }
 

--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -162,6 +162,8 @@ public:
     sai_port_priority_flow_control_mode_t m_pfc_asym = SAI_PORT_PRIORITY_FLOW_CONTROL_MODE_COMBINED;
     uint8_t   m_pfc_bitmask = 0;        // PFC enable bit mask
     uint8_t   m_pfcwd_sw_bitmask = 0;   // PFC software watchdog enable
+    uint8_t   m_host_tx_queue = 0;
+    bool      m_host_tx_queue_configured = false;
     uint16_t  m_tpid = DEFAULT_TPID;
     uint32_t  m_nat_zone_id = 0;
     uint32_t  m_vnid = VNID_NONE;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3510,6 +3510,11 @@ bool PortsOrch::initPort(const PortConfig &port)
                     m_recircPortRole[alias] = role;
                 }
 
+                if (p.m_host_tx_queue_configured)
+                {
+                    createPortBufferQueueCounters(p, to_string(p.m_host_tx_queue), false);
+                }
+
                 SWSS_LOG_NOTICE("Initialized port %s", alias.c_str());
             }
             else
@@ -3538,6 +3543,11 @@ void PortsOrch::deInitPort(string alias, sai_object_id_t port_id)
     {
         SWSS_LOG_ERROR("Failed to get port object for port id 0x%" PRIx64, port_id);
         return;
+    }
+
+    if (p.m_host_tx_queue_configured)
+    {
+        removePortBufferQueueCounters(p, to_string(p.m_host_tx_queue), false);
     }
 
     /* remove port from flex_counter_table for updating counters  */
@@ -5951,6 +5961,9 @@ bool PortsOrch::addHostIntfs(Port &port, string alias, sai_object_id_t &host_int
         attr.id = SAI_HOSTIF_ATTR_QUEUE;
         attr.value.u32 = DEFAULT_HOSTIF_TX_QUEUE;
         attrs.push_back(attr);
+
+        port.m_host_tx_queue = DEFAULT_HOSTIF_TX_QUEUE;
+        port.m_host_tx_queue_configured = true;
     }
 
     sai_status_t status = sai_hostif_api->create_hostif(&host_intfs_id, gSwitchId, (uint32_t)attrs.size(), attrs.data());
@@ -7258,6 +7271,10 @@ void PortsOrch::generateQueueMap(map<string, FlexCounterQueueStates> queuesState
                 {
                     flexCounterQueueState.enableQueueCounters(0, maxQueueNumber - 1);
                 }
+                else if (it.second.m_host_tx_queue_configured && it.second.m_host_tx_queue <= maxQueueNumber)
+                {
+                    flexCounterQueueState.enableQueueCounters(it.second.m_host_tx_queue, it.second.m_host_tx_queue);
+                }
                 queuesStateVector.insert(make_pair(it.second.m_alias, flexCounterQueueState));
             }
             generateQueueMapPerPort(it.second, queuesStateVector.at(it.second.m_alias), false);
@@ -7396,6 +7413,10 @@ void PortsOrch::addQueueFlexCounters(map<string, FlexCounterQueueStates> queuesS
                 {
                     flexCounterQueueState.enableQueueCounters(0, maxQueueNumber - 1);
                 }
+                else if (it.second.m_host_tx_queue_configured && it.second.m_host_tx_queue <= maxQueueNumber)
+                {
+                    flexCounterQueueState.enableQueueCounters(it.second.m_host_tx_queue, it.second.m_host_tx_queue);
+                }
                 queuesStateVector.insert(make_pair(it.second.m_alias, flexCounterQueueState));
             }
             addQueueFlexCountersPerPort(it.second, queuesStateVector.at(it.second.m_alias));
@@ -7477,6 +7498,10 @@ void PortsOrch::addQueueWatermarkFlexCounters(map<string, FlexCounterQueueStates
                 {
                     flexCounterQueueState.enableQueueCounters(0, maxQueueNumber - 1);
                 }
+                else if (it.second.m_host_tx_queue_configured && it.second.m_host_tx_queue <= maxQueueNumber)
+                {
+                    flexCounterQueueState.enableQueueCounters(it.second.m_host_tx_queue, it.second.m_host_tx_queue);
+                }
                 queuesStateVector.insert(make_pair(it.second.m_alias, flexCounterQueueState));
             }
             addQueueWatermarkFlexCountersPerPort(it.second, queuesStateVector.at(it.second.m_alias));
@@ -7524,7 +7549,7 @@ void PortsOrch::addQueueWatermarkFlexCountersPerPortPerQueueIndex(const Port& po
     startFlexCounterPolling(gSwitchId, key, counters_str, QUEUE_COUNTER_ID_LIST);
 }
 
-void PortsOrch::createPortBufferQueueCounters(const Port &port, string queues)
+void PortsOrch::createPortBufferQueueCounters(const Port &port, string queues, bool skip_host_tx_queue)
 {
     SWSS_LOG_ENTER();
 
@@ -7544,6 +7569,11 @@ void PortsOrch::createPortBufferQueueCounters(const Port &port, string queues)
 
     for (auto queueIndex = startIndex; queueIndex <= endIndex; queueIndex++)
     {
+        if (queueIndex == (uint32_t)port.m_host_tx_queue && skip_host_tx_queue)
+        {
+            continue;
+        }
+
         std::ostringstream name;
         name << port.m_alias << ":" << queueIndex;
 
@@ -7581,7 +7611,7 @@ void PortsOrch::createPortBufferQueueCounters(const Port &port, string queues)
     CounterCheckOrch::getInstance().addPort(port);
 }
 
-void PortsOrch::removePortBufferQueueCounters(const Port &port, string queues)
+void PortsOrch::removePortBufferQueueCounters(const Port &port, string queues, bool skip_host_tx_queue)
 {
     SWSS_LOG_ENTER();
 
@@ -7597,6 +7627,11 @@ void PortsOrch::removePortBufferQueueCounters(const Port &port, string queues)
 
     for (auto queueIndex = startIndex; queueIndex <= endIndex; queueIndex++)
     {
+        if (queueIndex == (uint32_t)port.m_host_tx_queue && skip_host_tx_queue)
+        {
+            continue;
+        }
+
         std::ostringstream name;
         name << port.m_alias << ":" << queueIndex;
         const auto id = sai_serialize_object_id(port.m_queue_ids[queueIndex]);

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -184,8 +184,8 @@ public:
 
     void generateQueueMap(map<string, FlexCounterQueueStates> queuesStateVector);
     uint32_t getNumberOfPortSupportedQueueCounters(string port);
-    void createPortBufferQueueCounters(const Port &port, string queues);
-    void removePortBufferQueueCounters(const Port &port, string queues);
+    void createPortBufferQueueCounters(const Port &port, string queues, bool skip_host_tx_queue=true);
+    void removePortBufferQueueCounters(const Port &port, string queues, bool skip_host_tx_queue=true);
     void addQueueFlexCounters(map<string, FlexCounterQueueStates> queuesStateVector);
     void addQueueWatermarkFlexCounters(map<string, FlexCounterQueueStates> queuesStateVector);
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**
Verified the following scenarios

1. No BUFFER_QUEUE covering host CPU queue
```
       Port    TxQ    Counter/pkts    Counter/bytes    Drop/pkts    Drop/bytes
-----------  -----  --------------  ---------------  -----------  ------------
Ethernet248    UC0               0                0            0           N/A
Ethernet248    UC1               0                0            0           N/A
Ethernet248    UC2               0                0            0           N/A
Ethernet248    UC3               0                0            0           N/A
Ethernet248    UC4               0                0            0           N/A
Ethernet248    UC5               0                0            0           N/A
Ethernet248    UC6               0                0            0           N/A
Ethernet248    UC7             287            61730            0           N/A

admin@r-leopard-simx-74:~$ redis-cli -n 4
127.0.0.1:6379[4]> keys BUFFER_QUEUE*Ethernet248*
1) "BUFFER_QUEUE|Ethernet248|0-2"
2) "BUFFER_QUEUE|Ethernet248|5-6"
3) "BUFFER_QUEUE|Ethernet248|3-4"
```
2. Remove irrelevant BUFFER_QUEUE on the port
```
admin@r-leopard-simx-74:~$ redis-cli -n 4          
127.0.0.1:6379[4]> del BUFFER_QUEUE|Ethernet248|5-6
(integer) 1
127.0.0.1:6379[4]> 
admin@r-leopard-simx-74:~$ queuestat -p Ethernet248
       Port    TxQ    Counter/pkts    Counter/bytes    Drop/pkts    Drop/bytes
-----------  -----  --------------  ---------------  -----------  ------------
Ethernet248    UC0               0                0            0           N/A
Ethernet248    UC1               0                0            0           N/A
Ethernet248    UC2               0                0            0           N/A
Ethernet248    UC3               0                0            0           N/A
Ethernet248    UC4               0                0            0           N/A
Ethernet248    UC7             294            63022            0           N/A
```
3. Reconfig BUFFER_QEUUE covering host CPU queue
```
admin@r-leopard-simx-74:~$ redis-cli -n 4          
127.0.0.1:6379[4]> hset BUFFER_QUEUE|Ethernet248|5-7 profile q_lossy_profile
(integer) 1
127.0.0.1:6379[4]> exit
admin@r-leopard-simx-74:~$ queuestat -p Ethernet248
       Port    TxQ    Counter/pkts    Counter/bytes    Drop/pkts    Drop/bytes
-----------  -----  --------------  ---------------  -----------  ------------
Ethernet248    UC0               0                0            0           N/A
Ethernet248    UC1               0                0            0           N/A
Ethernet248    UC2               0                0            0           N/A
Ethernet248    UC3               0                0            0           N/A
Ethernet248    UC4               0                0            0           N/A
Ethernet248    UC5               0                0            0           N/A
Ethernet248    UC6               0                0            0           N/A
Ethernet248    UC7             298            63934            0           N/A
```
4. Remove the configured BUFFER_QUEUE
```
admin@r-leopard-simx-74:~$ redis-cli -n 4          
127.0.0.1:6379[4]> del BUFFER_QUEUE|Ethernet248|5-7
(integer) 1
127.0.0.1:6379[4]> exit
admin@r-leopard-simx-74:~$ queuestat -p Ethernet248
       Port    TxQ    Counter/pkts    Counter/bytes    Drop/pkts    Drop/bytes
-----------  -----  --------------  ---------------  -----------  ------------
Ethernet248    UC0               0                0            0           N/A
Ethernet248    UC1               0                0            0           N/A
Ethernet248    UC2               0                0            0           N/A
Ethernet248    UC3               0                0            0           N/A
Ethernet248    UC4               0                0            0           N/A
Ethernet248    UC7             305            64818            0           N/A
```

**Details if related**
