### PR TITLE
Avoid removing a VRF routing table when there are pending creation entries in gRouteBulker  

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -11,6 +11,7 @@
 #include "timer.h"
 #include "crmorch.h"
 #include "sai_serialize.h"
+#include "directory.h"
 
 using namespace std;
 using namespace swss;
@@ -30,6 +31,7 @@ extern PortsOrch*        gPortsOrch;
 extern CrmOrch *gCrmOrch;
 extern SwitchOrch *gSwitchOrch;
 extern string gMySwitchType;
+extern Directory<Orch*> gDirectory;
 
 #define MIN_VLAN_ID 1    // 0 is a reserved VLAN ID
 #define MAX_VLAN_ID 4095 // 4096 is a reserved VLAN ID
@@ -615,6 +617,35 @@ bool AclTableRangeMatch::validateAclRuleMatch(const AclRule& rule) const
     }
 
     return true;
+}
+
+void AclRule::TunnelNH::load(const std::string& target)
+{
+    parse(target);
+
+    VxlanTunnelOrch* vxlan_orch = gDirectory.get<VxlanTunnelOrch*>();
+    /* Only the first call creates the SAI object, further calls just increment the ref count */
+    oid = vxlan_orch->createNextHopTunnel(tunnel_name, endpoint_ip, mac, vni);
+}
+
+void AclRule::TunnelNH::parse(const std::string& target)
+{
+    /* Supported Format: endpoint_ip@tunnel_name */
+    auto at_pos = target.find('@');
+    if (at_pos == std::string::npos)
+    {
+        throw std::logic_error("Invalid format for Tunnel Next Hop");
+    }
+
+    endpoint_ip = swss::IpAddress(target.substr(0, at_pos));
+    tunnel_name = target.substr(at_pos + 1);
+}
+
+void AclRule::TunnelNH::clear()
+{
+    oid = SAI_NULL_OBJECT_ID;
+    VxlanTunnelOrch* vxlan_orch = gDirectory.get<VxlanTunnelOrch*>();
+    vxlan_orch->removeNextHopTunnel(tunnel_name, endpoint_ip, mac, vni);
 }
 
 string AclTableType::getName() const
@@ -1308,7 +1339,17 @@ void AclRule::decreaseNextHopRefCount()
         }
         m_redirect_target_next_hop_group.clear();
     }
-
+    if (m_redirect_target_tun_nh.oid != SAI_NULL_OBJECT_ID)
+    {
+        try
+        {
+            m_redirect_target_tun_nh.clear();
+        }
+        catch (const std::runtime_error& e)
+        {
+            SWSS_LOG_ERROR("Failed to remove tunnel nh reference %s, ACL Rule: %s", e.what(), m_id.c_str());
+        }
+    }
     return;
 }
 
@@ -2001,19 +2042,36 @@ sai_object_id_t AclRulePacket::getRedirectObjectId(const string& redirect_value)
     try
     {
         NextHopKey nh(target);
-        if (!m_pAclOrch->m_neighOrch->hasNextHop(nh))
+        if (m_pAclOrch->m_neighOrch->hasNextHop(nh))
         {
-            SWSS_LOG_ERROR("ACL Redirect action target next hop ip: '%s' doesn't exist on the switch", nh.to_string().c_str());
-            return SAI_NULL_OBJECT_ID;
+            m_redirect_target_next_hop = target;
+            m_pAclOrch->m_neighOrch->increaseNextHopRefCount(nh);
+            return m_pAclOrch->m_neighOrch->getNextHopId(nh);
         }
-
-        m_redirect_target_next_hop = target;
-        m_pAclOrch->m_neighOrch->increaseNextHopRefCount(nh);
-        return m_pAclOrch->m_neighOrch->getNextHopId(nh);
     }
     catch (...)
     {
         // no error, just try next variant
+    }
+
+    // Try to parse if this is a tunnel nexthop.
+    try
+    {
+        m_redirect_target_tun_nh.load(target);
+        if (SAI_NULL_OBJECT_ID != m_redirect_target_tun_nh.oid)
+        {
+            SWSS_LOG_INFO("Tunnel Next Hop Found: oid:0x%" PRIx64 ", target: %s", m_redirect_target_tun_nh.oid, target.c_str());
+            return m_redirect_target_tun_nh.oid;
+        }
+    }
+    catch (std::logic_error& e)
+    {
+        // no error, just try next variant
+    }
+    catch (const std::runtime_error& e)
+    {
+        SWSS_LOG_ERROR("Failed to create/fetch tunnel next hop, %s, err: %s", target.c_str(), e.what());
+        return SAI_NULL_OBJECT_ID;
     }
 
     // try to parse nh group the set of <ip address, interface name>

--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -15,6 +15,7 @@
 #include "mirrororch.h"
 #include "dtelorch.h"
 #include "observer.h"
+#include "vxlanorch.h"
 #include "flex_counter_manager.h"
 
 #include "acltable.h"
@@ -286,6 +287,22 @@ class AclTable;
 class AclRule
 {
 public:
+    struct TunnelNH
+    {
+        TunnelNH() = default;
+        ~TunnelNH() = default;
+
+        void load(const std::string& target);
+        void parse(const std::string& target);
+        void clear();
+
+        std::string tunnel_name;
+        swss::IpAddress endpoint_ip;
+        swss::MacAddress mac;
+        uint32_t vni = 0;
+        sai_object_id_t oid = SAI_NULL_OBJECT_ID;
+    };
+
     AclRule(AclOrch *pAclOrch, string rule, string table, bool createCounter = true);
     virtual bool validateAddPriority(string attr_name, string attr_value);
     virtual bool validateAddMatch(string attr_name, string attr_value);
@@ -359,6 +376,7 @@ protected:
     map <sai_acl_entry_attr_t, SaiAttrWrapper> m_matches;
     string m_redirect_target_next_hop;
     string m_redirect_target_next_hop_group;
+    AclRule::TunnelNH m_redirect_target_tun_nh;
 
     vector<AclRangeConfig> m_rangeConfig;
     vector<AclRange*> m_ranges;

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -2433,13 +2433,21 @@ bool RouteOrch::removeRoute(RouteBulkContext& ctx)
     size_t creating = gRouteBulker.creating_entries_count(route_entry);
     if (it_route == it_route_table->second.end() && creating == 0)
     {
-       if (it_route_table->second.size() == 0)
-       {
+        /*
+         * Clean up the VRF routing table if
+         * 1. there is no routing entry in the VRF routing table and
+         * 2. there is no pending creating rouing entry in gRouteBulker
+         * The ideal way of the 2nd condition is to check pending creating entries of a certain VRF, which we can not do.
+         * However, we can not check whether there is a pending creating entry of a certain VRF in the gRouteBulker
+         * So, we use a strict condition here.
+         */
+        if (it_route_table->second.size() == 0 && gRouteBulker.creating_entries_count() == 0)
+        {
             m_syncdRoutes.erase(vrf_id);
             m_vrfOrch->decreaseVrfRefCount(vrf_id);
-       }
-       SWSS_LOG_INFO("Failed to find route entry, vrf_id 0x%" PRIx64 ", prefix %s\n", vrf_id,
-                     ipPrefix.to_string().c_str());
+        }
+        SWSS_LOG_INFO("Failed to find route entry, vrf_id 0x%" PRIx64 ", prefix %s\n", vrf_id,
+                      ipPrefix.to_string().c_str());
  
         return true;
     }

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -2436,10 +2436,10 @@ bool RouteOrch::removeRoute(RouteBulkContext& ctx)
         /*
          * Clean up the VRF routing table if
          * 1. there is no routing entry in the VRF routing table and
-         * 2. there is no pending creating rouing entry in gRouteBulker
-         * The ideal way of the 2nd condition is to check pending creating entries of a certain VRF, which we can not do.
-         * However, we can not check whether there is a pending creating entry of a certain VRF in the gRouteBulker
-         * So, we use a strict condition here.
+         * 2. there is no pending bulk creation routing entry in gRouteBulker
+         * The ideal way of the 2nd condition is to check pending bulk creation entries of a certain VRF.
+         * However, we can not do that unless going over all entries in gRouteBulker.
+         * So, we use above strict conditions here
          */
         if (it_route_table->second.size() == 0 && gRouteBulker.creating_entries_count() == 0)
         {

--- a/orchagent/swssnet.h
+++ b/orchagent/swssnet.h
@@ -64,6 +64,7 @@ inline static sai_ip_prefix_t& copy(sai_ip_prefix_t& dst, const IpAddress& src)
     switch(sip.family)
     {
         case AF_INET:
+            memset((void*)&dst, 0, sizeof(dst));
             dst.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
             dst.addr.ip4 = sip.ip_addr.ipv4_addr;
             dst.mask.ip4 = 0xFFFFFFFF;

--- a/orchagent/swssnet.h
+++ b/orchagent/swssnet.h
@@ -21,6 +21,7 @@ inline static sai_ip_address_t& copy(sai_ip_address_t& dst, const IpAddress& src
     switch(sip.family)
     {
         case AF_INET:
+            memset((void*)&dst.addr, 0, sizeof(dst.addr));
             dst.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
             dst.addr.ip4 = sip.ip_addr.ipv4_addr;
             break;
@@ -41,6 +42,7 @@ inline static sai_ip_prefix_t& copy(sai_ip_prefix_t& dst, const IpPrefix& src)
     switch(ia.family)
     {
         case AF_INET:
+            memset((void*)&dst, 0, sizeof(dst));
             dst.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
             dst.addr.ip4 = ia.ip_addr.ipv4_addr;
             dst.mask.ip4 = ma.ip_addr.ipv4_addr;

--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -1329,10 +1329,6 @@ VxlanTunnelOrch::createNextHopTunnel(string tunnelName, IpAddress& ipAddr,
         return SAI_NULL_OBJECT_ID;
     }
 
-    SWSS_LOG_NOTICE("NH tunnel create for %s, ip %s, mac %s, vni %d",
-                     tunnelName.c_str(), ipAddr.to_string().c_str(), 
-                     macAddress.to_string().c_str(), vni);
-
     auto tunnel_obj = getVxlanTunnel(tunnelName);
     sai_object_id_t nh_id, tunnel_id = tunnel_obj->getTunnelId();
 
@@ -1341,6 +1337,10 @@ VxlanTunnelOrch::createNextHopTunnel(string tunnelName, IpAddress& ipAddr,
         tunnel_obj->incNextHopRefCount(ipAddr, macAddress, vni);
         return nh_id;
     }
+
+    SWSS_LOG_NOTICE("NH tunnel create for %s, ip %s, mac %s, vni %d",
+                    tunnelName.c_str(), ipAddr.to_string().c_str(), 
+                    macAddress.to_string().c_str(), vni);
 
     sai_ip_address_t host_ip;
     swss::copy(host_ip, ipAddr);

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -26,6 +26,7 @@ LDADD_GTEST = -L/usr/src/gtest
 tests_INCLUDES = -I $(FLEX_CTR_DIR) -I $(DEBUG_CTR_DIR) -I $(top_srcdir)/lib -I$(top_srcdir)/cfgmgr -I$(top_srcdir)/orchagent -I$(P4_ORCH_DIR)/tests -I$(DASH_ORCH_DIR) -I$(top_srcdir)/warmrestart
 
 tests_SOURCES = aclorch_ut.cpp \
+                aclorch_rule_ut.cpp \
                 portsorch_ut.cpp \
                 routeorch_ut.cpp \
                 qosorch_ut.cpp \

--- a/tests/mock_tests/aclorch_rule_ut.cpp
+++ b/tests/mock_tests/aclorch_rule_ut.cpp
@@ -1,0 +1,296 @@
+#include "ut_helper.h"
+#include "mock_orchagent_main.h"
+#include "mock_sai_api.h"
+#include "mock_orch_test.h"
+#include "check.h"
+
+EXTERN_MOCK_FNS
+
+/* 
+    This test provides a framework to mock create_acl_entry & remove_acl_entry API's
+*/
+namespace aclorch_rule_test
+{
+    DEFINE_SAI_GENERIC_API_MOCK(acl, acl_entry);
+    /* To mock Redirect Action functionality */
+    DEFINE_SAI_GENERIC_API_MOCK(next_hop, next_hop);
+    
+    using namespace ::testing;
+    using namespace std;
+    using namespace saimeta;
+    using namespace swss;
+    using namespace mock_orch_test;
+
+    struct SaiMockState
+    {
+        /* Add extra attributes on demand */
+        vector<sai_attribute_t> create_attrs;
+        sai_status_t create_status = SAI_STATUS_SUCCESS;
+        sai_status_t remove_status = SAI_STATUS_SUCCESS;
+        sai_object_id_t remove_oid;
+        sai_object_id_t create_oid;
+
+        sai_status_t handleCreate(sai_object_id_t *sai, sai_object_id_t switch_id, uint32_t attr_count, const sai_attribute_t *attr_list)
+        {
+            *sai = create_oid;
+            create_attrs.clear();
+            for (uint32_t i = 0; i < attr_count; ++i)
+            {
+                create_attrs.emplace_back(attr_list[i]);
+            }
+            return create_status;
+        }
+
+        sai_status_t handleRemove(sai_object_id_t oid)
+        {
+            EXPECT_EQ(oid, remove_oid);
+            return remove_status;
+        } 
+    };
+
+    struct AclOrchRuleTest : public MockOrchTest
+    {   
+        unique_ptr<SaiMockState> aclMockState;
+
+        void PostSetUp() override
+        {
+            INIT_SAI_API_MOCK(acl);
+            INIT_SAI_API_MOCK(next_hop);
+            MockSaiApis();
+
+            aclMockState = make_unique<SaiMockState>();
+            /* Port init done is a pre-req for Aclorch */
+            auto consumer = unique_ptr<Consumer>(new Consumer(
+                new swss::ConsumerStateTable(m_app_db.get(), APP_PORT_TABLE_NAME, 1, 1), gPortsOrch, APP_PORT_TABLE_NAME));
+            consumer->addToSync({ { "PortInitDone", EMPTY_PREFIX, { { "", "" } } } });
+            static_cast<Orch *>(gPortsOrch)->doTask(*consumer.get());
+        }
+
+        void PreTearDown() override
+        {
+            aclMockState.reset();
+            RestoreSaiApis();
+            DEINIT_SAI_API_MOCK(next_hop);
+            DEINIT_SAI_API_MOCK(acl);
+        }
+
+        void doAclTableTypeTask(const deque<KeyOpFieldsValuesTuple> &entries)
+        {
+            auto consumer = unique_ptr<Consumer>(new Consumer(
+                new swss::ConsumerStateTable(m_config_db.get(), CFG_ACL_TABLE_TYPE_TABLE_NAME, 1, 1), 
+                    gAclOrch, CFG_ACL_TABLE_TYPE_TABLE_NAME));
+            consumer->addToSync(entries);
+            static_cast<Orch *>(gAclOrch)->doTask(*consumer);
+        }
+
+        void doAclTableTask(const deque<KeyOpFieldsValuesTuple> &entries)
+        {
+            auto consumer = unique_ptr<Consumer>(new Consumer(
+                new swss::ConsumerStateTable(m_config_db.get(), CFG_ACL_TABLE_TABLE_NAME, 1, 1), 
+                    gAclOrch, CFG_ACL_TABLE_TABLE_NAME));
+            consumer->addToSync(entries);
+            static_cast<Orch *>(gAclOrch)->doTask(*consumer);
+        }
+
+        void doAclRuleTask(const deque<KeyOpFieldsValuesTuple> &entries)
+        {
+            auto consumer = unique_ptr<Consumer>(new Consumer(
+                new swss::ConsumerStateTable(m_config_db.get(), CFG_ACL_RULE_TABLE_NAME, 1, 1), 
+                    gAclOrch, CFG_ACL_RULE_TABLE_NAME));
+            consumer->addToSync(entries);
+            static_cast<Orch *>(gAclOrch)->doTask(*consumer);
+        }
+    };
+
+    struct AclRedirectActionTest : public AclOrchRuleTest
+    {    
+        string acl_table_type = "TEST_ACL_TABLE_TYPE";
+        string acl_table = "TEST_ACL_TABLE";
+        string acl_rule = "TEST_ACL_RULE";
+
+        string mock_tunnel_name = "tunnel0";
+        string mock_invalid_tunnel_name = "tunnel1";
+        string mock_src_ip = "20.0.0.1";
+        string mock_nh_ip_str = "20.0.0.3";
+        string mock_invalid_nh_ip_str = "20.0.0.4";
+        sai_object_id_t nh_oid = 0x400000000064d;
+
+        void PostSetUp() override
+        {
+            AclOrchRuleTest::PostSetUp();
+
+            /* Create a tunnel */
+            auto consumer = unique_ptr<Consumer>(new Consumer(
+                new swss::ConsumerStateTable(m_app_db.get(), APP_VXLAN_TUNNEL_TABLE_NAME, 1, 1),
+                                             m_VxlanTunnelOrch, APP_VXLAN_TUNNEL_TABLE_NAME));
+
+            consumer->addToSync(
+                deque<KeyOpFieldsValuesTuple>(
+                    {
+                            {
+                                mock_tunnel_name,
+                                SET_COMMAND,
+                                {
+                                    { "src_ip", mock_src_ip }
+                                }
+                            }
+                    }
+            ));
+            static_cast<Orch2*>(m_VxlanTunnelOrch)->doTask(*consumer.get());
+
+            populateAclTale();
+            setDefaultMockState();
+        }
+
+        void PreTearDown() override
+        {
+            AclOrchRuleTest::PreTearDown();
+
+            /* Delete the Tunnel Object */
+            auto consumer = unique_ptr<Consumer>(new Consumer(
+                new swss::ConsumerStateTable(m_app_db.get(), APP_VXLAN_TUNNEL_TABLE_NAME, 1, 1),
+                                             m_VxlanTunnelOrch, APP_VXLAN_TUNNEL_TABLE_NAME));
+
+            consumer->addToSync(
+                deque<KeyOpFieldsValuesTuple>(
+                    {
+                            {
+                                mock_tunnel_name,
+                                DEL_COMMAND,
+                                { }
+                            }
+                    }
+            ));
+            static_cast<Orch2*>(m_VxlanTunnelOrch)->doTask(*consumer.get());
+        }
+
+        void createTunnelNH(string ip)
+        {
+            IpAddress mock_nh_ip(ip);
+            ASSERT_EQ(m_VxlanTunnelOrch->createNextHopTunnel(mock_tunnel_name, mock_nh_ip, MacAddress()), nh_oid);
+        }
+
+        void populateAclTale()
+        {
+            /* Create a Table type and Table */
+            doAclTableTypeTask({
+                {
+                    acl_table_type,
+                    SET_COMMAND,
+                    {
+                        { ACL_TABLE_TYPE_MATCHES, MATCH_DST_IP },
+                        { ACL_TABLE_TYPE_ACTIONS, ACTION_REDIRECT_ACTION }
+                    } 
+                }
+            });
+            doAclTableTask({
+                {
+                    acl_table,
+                    SET_COMMAND,
+                    {
+                        { ACL_TABLE_TYPE, acl_table_type },
+                        { ACL_TABLE_STAGE, STAGE_INGRESS },
+                    } 
+                }
+            });
+        }
+
+        void addTunnelNhRule(string ip, string tunnel_name)
+        {
+            /* Create a rule */
+            doAclRuleTask({
+                {
+                    acl_table + "|" + acl_rule,
+                    SET_COMMAND,
+                    {
+                        { RULE_PRIORITY, "9999" },
+                        { MATCH_DST_IP, "10.0.0.1/24" },
+                        { ACTION_REDIRECT_ACTION, ip + "@" + tunnel_name }
+                    } 
+                }
+            });
+        }
+
+        void delTunnelNhRule()
+        {
+            doAclRuleTask(
+            {
+                {
+                    acl_table + "|" + acl_rule,
+                    DEL_COMMAND,
+                    { } 
+                }
+            });
+        }
+
+        void setDefaultMockState()
+        {
+            aclMockState->create_status = SAI_STATUS_SUCCESS;
+            aclMockState->remove_status = SAI_STATUS_SUCCESS;
+            aclMockState->create_oid = nh_oid;
+            aclMockState->remove_oid = nh_oid;
+        }
+    };
+
+    TEST_F(AclRedirectActionTest, TunnelNH)
+    {
+        EXPECT_CALL(*mock_sai_next_hop_api, create_next_hop).WillOnce(DoAll(SetArgPointee<0>(nh_oid),
+                Return(SAI_STATUS_SUCCESS)
+        ));
+        EXPECT_CALL(*mock_sai_acl_api, create_acl_entry).WillOnce(testing::Invoke(aclMockState.get(), &SaiMockState::handleCreate));     
+        addTunnelNhRule(mock_nh_ip_str, mock_tunnel_name);
+
+        /* Verify SAI attributes and if the rule is created */
+        SaiAttributeList attr_list(SAI_OBJECT_TYPE_ACL_ENTRY, vector<swss::FieldValueTuple>({ 
+              { "SAI_ACL_ENTRY_ATTR_TABLE_ID", sai_serialize_object_id(gAclOrch->getTableById(acl_table)) },
+              { "SAI_ACL_ENTRY_ATTR_PRIORITY", "9999" },
+              { "SAI_ACL_ENTRY_ATTR_ADMIN_STATE", "true" },
+              { "SAI_ACL_ENTRY_ATTR_ACTION_COUNTER", "oid:0xfffffffffff"},
+              { "SAI_ACL_ENTRY_ATTR_FIELD_DST_IP", "10.0.0.1&mask:255.255.255.0"},
+              { "SAI_ACL_ENTRY_ATTR_ACTION_REDIRECT", sai_serialize_object_id(nh_oid) }
+        }), false);
+        vector<bool> skip_list = {false, false, false, true, false, false}; /* skip checking counter */
+        ASSERT_TRUE(Check::AttrListSubset(SAI_OBJECT_TYPE_ACL_ENTRY, aclMockState->create_attrs, attr_list, skip_list));
+        ASSERT_TRUE(gAclOrch->getAclRule(acl_table, acl_rule));
+
+        /* ACLRule is deleted along with Nexthop */
+        EXPECT_CALL(*mock_sai_next_hop_api, remove_next_hop).Times(1).WillOnce(Return(SAI_STATUS_SUCCESS));
+        EXPECT_CALL(*mock_sai_acl_api, remove_acl_entry).WillOnce(testing::Invoke(aclMockState.get(), &SaiMockState::handleRemove));
+        delTunnelNhRule();
+        ASSERT_FALSE(gAclOrch->getAclRule(acl_table, acl_rule));
+    }
+
+    TEST_F(AclRedirectActionTest, TunnelNH_ExistingNhObject)
+    {
+        EXPECT_CALL(*mock_sai_next_hop_api, create_next_hop).WillOnce(DoAll(SetArgPointee<0>(nh_oid),
+                Return(SAI_STATUS_SUCCESS)
+        ));
+        EXPECT_CALL(*mock_sai_acl_api, create_acl_entry).WillOnce(testing::Invoke(aclMockState.get(), &SaiMockState::handleCreate));
+        createTunnelNH(mock_nh_ip_str);
+        addTunnelNhRule(mock_nh_ip_str, mock_tunnel_name);
+        ASSERT_TRUE(gAclOrch->getAclRule(acl_table, acl_rule));
+
+        /* ACL Rule is deleted but nexthop is not deleted */
+        EXPECT_CALL(*mock_sai_acl_api, remove_acl_entry).WillOnce(testing::Invoke(aclMockState.get(), &SaiMockState::handleRemove));
+        EXPECT_CALL(*mock_sai_next_hop_api, remove_next_hop).Times(0);
+        delTunnelNhRule();
+        ASSERT_FALSE(gAclOrch->getAclRule(acl_table, acl_rule));
+    }
+
+    TEST_F(AclRedirectActionTest, TunnelNH_InvalidTunnel)
+    {
+        EXPECT_CALL(*mock_sai_acl_api, create_acl_entry).Times(0);
+        addTunnelNhRule(mock_nh_ip_str, mock_invalid_tunnel_name);
+        ASSERT_FALSE(gAclOrch->getAclRule(acl_table, acl_rule));
+    }
+
+    TEST_F(AclRedirectActionTest, TunnelNH_InvalidNextHop)
+    {
+        EXPECT_CALL(*mock_sai_next_hop_api, create_next_hop).WillOnce(
+                Return(SAI_STATUS_FAILURE) /* create next hop fails */
+        );
+        EXPECT_CALL(*mock_sai_acl_api, create_acl_entry).Times(0);
+        addTunnelNhRule(mock_invalid_nh_ip_str, mock_tunnel_name);
+        ASSERT_FALSE(gAclOrch->getAclRule(acl_table, acl_rule));
+    }
+}

--- a/tests/mock_tests/check.h
+++ b/tests/mock_tests/check.h
@@ -42,40 +42,94 @@ struct Check
                         std::cerr << "Expected: " << meta->attridname << "\n";
                     }
                 }
-
                 continue;
             }
 
-            const int MAX_BUF_SIZE = 0x4000;
-            std::string act_str;
-            std::string exp_str;
-
-            act_str.reserve(MAX_BUF_SIZE);
-            exp_str.reserve(MAX_BUF_SIZE);
-
-            auto act_len = sai_serialize_attribute_value(&act_str[0], meta, &act_attr_list[i].value);
-            auto exp_len = sai_serialize_attribute_value(&exp_str[0], meta, &exp_attr_list.get_attr_list()[i].value);
-
-            assert(act_len < act_str.size());
-            assert(act_len < exp_str.size());
-
-            if (act_len != exp_len)
+            const sai_attribute_t* act = &act_attr_list[i];
+            const sai_attribute_t* exp = &exp_attr_list.get_attr_list()[i];
+            if (!Check::AttrValue(objecttype, id, act, exp))
             {
-                std::cerr << "AttrListEq failed\n";
-                std::cerr << "Actual:   " << act_str << "\n";
-                std::cerr << "Expected: " << exp_str << "\n";
-                return false;
-            }
-
-            if (act_str != exp_str)
-            {
-                std::cerr << "AttrListEq failed\n";
-                std::cerr << "Actual:   " << act_str << "\n";
-                std::cerr << "Expected: " << exp_str << "\n";
                 return false;
             }
         }
 
+        return true;
+    }
+
+    static bool AttrValue(sai_object_type_t objecttype, sai_attr_id_t id, const sai_attribute_t* act, const sai_attribute_t* exp)
+    {
+        auto meta = sai_metadata_get_attr_metadata(objecttype, id);
+        assert(meta != nullptr);
+
+        const int MAX_BUF_SIZE = 0x4000;
+        std::vector<char> act_buf(MAX_BUF_SIZE);
+        std::vector<char> exp_buf(MAX_BUF_SIZE);
+
+        act_buf.reserve(MAX_BUF_SIZE);
+        exp_buf.reserve(MAX_BUF_SIZE);
+
+        auto act_len = sai_serialize_attribute_value(act_buf.data(), meta, &act->value);
+        auto exp_len = sai_serialize_attribute_value(exp_buf.data(), meta, &exp->value);
+
+        assert(act_len < act_str.size());
+        assert(act_len < exp_str.size());
+
+        act_buf.resize(act_len);
+        exp_buf.resize(exp_len);
+
+        std::string act_str(act_buf.begin(), act_buf.end());
+        std::string exp_str(exp_buf.begin(), exp_buf.end());
+
+        if (act_len != exp_len)
+        {
+            std::cerr << "AttrValue length failed\n";
+            std::cerr << "Actual:   " << act_len << "," << act_str << "\n";
+            std::cerr << "Expected: " << exp_len << "," << exp_str << "\n";
+            return false;
+        }
+
+        if (act_str != exp_str)
+        {
+            std::cerr << "AttrValue string failed\n";
+            std::cerr << "Actual:   " << act_str << "\n";
+            std::cerr << "Expected: " << exp_str << "\n";
+            return false;
+        }
+        return true;
+    }
+
+    static bool AttrListSubset(sai_object_type_t objecttype, const std::vector<sai_attribute_t> &act_attr_list,
+                               saimeta::SaiAttributeList &exp_attr_list, const std::vector<bool> skip_check)
+    {
+        /* 
+            Size of attributes should be equal and in the same order. 
+            If the validation has to be skipped for certain attributes populate the skip_check.
+        */
+        if (act_attr_list.size() != exp_attr_list.get_attr_count())
+        {
+            std::cerr << "AttrListSubset size mismatch\n";
+            return false;
+        }
+        if (act_attr_list.size() != skip_check.size())
+        {
+            std::cerr << "AttrListSubset size mismatch\n";
+            return false;
+        }
+
+        for (uint32_t i = 0; i < exp_attr_list.get_attr_count(); ++i)
+        {
+            if (skip_check[i])
+            {
+                continue;
+            }
+            sai_attr_id_t id = exp_attr_list.get_attr_list()[i].id;
+            const sai_attribute_t* act = &act_attr_list[i];
+            const sai_attribute_t* exp = &exp_attr_list.get_attr_list()[i];
+            if (!Check::AttrValue(objecttype, id, act, exp))
+            {
+                return false;
+            }
+        }
         return true;
     }
 };

--- a/tests/mock_tests/mock_sai_api.h
+++ b/tests/mock_tests/mock_sai_api.h
@@ -11,6 +11,7 @@ To mock a particular SAI API:
 3. In the SetUp method of the test class, call INIT_SAI_API_MOCK for each SAI API you want to mock.
 4. In the SetUp method of the test class, call MockSaiApis.
 5. In the TearDown method of the test class, call RestoreSaiApis.
+6. After RestoreSaiApis, call DEINIT_SAI_API_MOCK
 */
 
 using ::testing::Return;
@@ -241,6 +242,14 @@ The macro DEFINE_SAI_API_MOCK will perform the steps to mock the SAI API for the
 #define INIT_SAI_API_MOCK(sai_object_type)                          \
     apply_mock_fns.insert(&apply_sai_##sai_object_type##_api_mock); \
     remove_mock_fns.insert(&remove_sai_##sai_object_type##_api_mock);
+
+/*
+    Call this after RestoreSaiApis to clear the mock_fns
+    Required when same SAI_API is being mocked in multiple files eg: acl API in multiple tests
+*/
+#define DEINIT_SAI_API_MOCK(sai_object_type)                          \
+    apply_mock_fns.erase(&apply_sai_##sai_object_type##_api_mock); \
+    remove_mock_fns.erase(&remove_sai_##sai_object_type##_api_mock);
 
 void MockSaiApis();
 void RestoreSaiApis();

--- a/tests/mock_tests/mux_rollback_ut.cpp
+++ b/tests/mock_tests/mux_rollback_ut.cpp
@@ -162,6 +162,10 @@ namespace mux_rollback_test
         void PreTearDown() override
         {
             RestoreSaiApis();
+            DEINIT_SAI_API_MOCK(next_hop);
+            DEINIT_SAI_API_MOCK(acl);
+            DEINIT_SAI_API_MOCK(route);
+            DEINIT_SAI_API_MOCK(neighbor);
             gNeighOrch->gNeighBulker.create_entries = old_create_neighbor_entries;
             gNeighOrch->gNeighBulker.remove_entries = old_remove_neighbor_entries;
             gNeighOrch->gNextHopBulker.create_entries = old_object_create;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Avoid removing a VRF routing table when there are pending creation entries in gRouteBulker

1. Remove a VRF routing table when a routing entry is removed only if there is no pending creation entry in gRouteBulker
2. Avoid uninitialized value SAI IP address/prefix structure

**Why I did it**

Fix issue: out of range exception can be thrown in `addRoutePost` due to non exist VRF

```
(gdb) bt
#0  0x00007f5791aedebc in ?? () from /lib/x86_64-linux-gnu/libc.so.6
#1  0x00007f5791a9efb2 in raise () from /lib/x86_64-linux-gnu/libc.so.6
#2  0x00007f5791a89472 in abort () from /lib/x86_64-linux-gnu/libc.so.6
#3  0x00007f5791de0919 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007f5791debe1a in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#5  0x00007f5791debe85 in std::terminate() () from /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007f5791dec0d8 in __cxa_throw () from /lib/x86_64-linux-gnu/libstdc++.so.6
#7  0x00007f5791de3240 in std::__throw_out_of_range(char const*) () from /lib/x86_64-linux-gnu/libstdc++.so.6
#8  0x00005594e856d956 in std::map<unsigned long, std::map<swss::IpPrefix, RouteNhg, std::less<swss::IpPrefix>, std::allocator<std::pair<swss::IpPrefix const, RouteNhg> > >, std::less<unsigned long>, std::allocator<std::pair<unsigned long const, std::map<swss::IpPrefix, RouteNhg, std::less<swss::IpPrefix>, std::allocator<std::pair<swss::IpPrefix const, RouteNhg> > > > > >::at (this=<optimized out>, __k=<optimized out>) at /usr/include/c++/12/bits/stl_map.h:551
#9  0x00005594e8564beb in RouteOrch::addRoutePost (this=this@entry=0x5594ea13e080, ctx=..., nextHops=...) at ./orchagent/routeorch.cpp:2145
#10 0x00005594e856b0b2 in RouteOrch::doTask (this=0x5594ea13e080, consumer=...) at ./orchagent/routeorch.cpp:1021
#11 0x00005594e85282d2 in Orch::doTask (this=0x5594ea13e080) at ./orchagent/orch.cpp:553
#12 0x00005594e851909a in OrchDaemon::start (this=this@entry=0x5594ea0a0950) at ./orchagent/orchdaemon.cpp:895
#13 0x00005594e8485632 in main (argc=<optimized out>, argv=<optimized out>) at ./orchagent/main.cpp:818
```

**How I verified it**

Unit (mock) test

**Details if related**

Originally, it cleaned up a VRF routing table whenever a prefix of the VRF was removed if
1. there was no routing entry in the VRF routing table and
2. the prefix was not pending creation in gRouteBulker

The motivation is to remove a VRF routing table if there is no routing entry in the VRF and no routing entry pending creation for that VRF. However, condition 2 does not guarantee that.

The ideal way of the 2nd condition is to check pending creation entries of a certain VRF, which we can not do.
So, we are using strict conditions here as the following:
1. there is no routing entry in the VRF routing table and
2. there is no pending creating routing entry in gRouteBulker regardless of which VRF it belongs to
