### PR TITLE
Initialize number of counters to 0 before querying the capabilities

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -1205,6 +1205,12 @@ void FdbOrch::updatePortOperState(const PortOperStateUpdate& update)
     if (update.operStatus == SAI_PORT_OPER_STATUS_DOWN)
     {
         swss::Port p = update.port;
+        if (gMlagOrch->isMlagInterface(p.m_alias))
+        {
+            SWSS_LOG_NOTICE("Ignoring fdb flush on MCLAG port:%s", p.m_alias.c_str());
+            return;
+        }
+
         if (p.m_bridge_port_id != SAI_NULL_OBJECT_ID)
         {
             flushFDBEntries(p.m_bridge_port_id, SAI_NULL_OBJECT_ID);

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1535,12 +1535,6 @@ void PortsOrch::initCounterCapabilities(sai_object_id_t switchId)
 {
     sai_stat_capability_list_t queue_stats_capability, port_stats_capability;
 
-    uint32_t  queue_stat_count = (uint32_t) queue_stat_ids.size() +
-                                 (uint32_t) queueWatermarkStatIds.size() +
-                                 (uint32_t) wred_queue_stat_ids.size();
-    uint32_t  port_stat_count = (uint32_t) port_stat_ids.size() +
-                                 (uint32_t) wred_port_stat_ids.size() +
-                                 (uint32_t) port_buffer_drop_stat_ids.size();
     uint32_t  it = 0;
     bool      pt_grn_pkt = false, pt_red_pkt = false, pt_ylw_pkt = false, pt_tot_pkt = false;
     bool      q_ecn_byte = false, q_ecn_pkt = false, q_wred_byte = false, q_wred_pkt = false;
@@ -1548,9 +1542,9 @@ void PortsOrch::initCounterCapabilities(sai_object_id_t switchId)
     sai_stat_capability_t stat_initializer;
     stat_initializer.stat_enum = 0;
     stat_initializer.stat_modes = 0;
-    vector<sai_stat_capability_t> qstat_cap_list(queue_stat_count, stat_initializer);
-    queue_stats_capability.count = queue_stat_count;
-    queue_stats_capability.list = qstat_cap_list.data();
+    vector<sai_stat_capability_t> qstat_cap_list;
+    queue_stats_capability.count = 0;
+    queue_stats_capability.list = nullptr;
 
     vector<FieldValueTuple> fieldValuesTrue;
     fieldValuesTrue.push_back(FieldValueTuple("isSupported", "true"));
@@ -1572,7 +1566,7 @@ void PortsOrch::initCounterCapabilities(sai_object_id_t switchId)
     sai_status_t status = sai_query_stats_capability(switchId, SAI_OBJECT_TYPE_QUEUE, &queue_stats_capability);
     if (status == SAI_STATUS_BUFFER_OVERFLOW)
     {
-        qstat_cap_list.resize(queue_stats_capability.count);
+        qstat_cap_list.resize(queue_stats_capability.count, stat_initializer);
         queue_stats_capability.list = qstat_cap_list.data();
         status = sai_query_stats_capability(switchId, SAI_OBJECT_TYPE_QUEUE, &queue_stats_capability);
     }
@@ -1611,15 +1605,15 @@ void PortsOrch::initCounterCapabilities(sai_object_id_t switchId)
         SWSS_LOG_NOTICE("Queue stat capability get failed: WRED queue stats can not be enabled, rv:%d", status);
     }
 
-    vector<sai_stat_capability_t> pstat_cap_list(port_stat_count, stat_initializer);
-    port_stats_capability.count = port_stat_count;
-    port_stats_capability.list = pstat_cap_list.data();
+    vector<sai_stat_capability_t> pstat_cap_list;
+    port_stats_capability.count = 0;
+    port_stats_capability.list = nullptr;
 
     /*  4. Get port stats capability from the platform*/
     status = sai_query_stats_capability(switchId, SAI_OBJECT_TYPE_PORT, &port_stats_capability);
     if (status == SAI_STATUS_BUFFER_OVERFLOW)
     {
-        pstat_cap_list.resize(port_stats_capability.count);
+        pstat_cap_list.resize(port_stats_capability.count, stat_initializer);
         port_stats_capability.list = pstat_cap_list.data();
         status = sai_query_stats_capability(switchId, SAI_OBJECT_TYPE_PORT, &port_stats_capability);
     }

--- a/tests/mock_tests/mock_orchagent_main.h
+++ b/tests/mock_tests/mock_orchagent_main.h
@@ -29,6 +29,7 @@
 #include "nhgorch.h"
 #include "copporch.h"
 #include "twamporch.h"
+#include "mlagorch.h"
 #define private public
 #include "stporch.h"
 #undef private 
@@ -64,6 +65,7 @@ extern AclOrch *gAclOrch;
 extern PolicerOrch *gPolicerOrch;
 extern TunnelDecapOrch *gTunneldecapOrch;
 extern StpOrch *gStpOrch;
+extern MlagOrch *gMlagOrch;
 extern Directory<Orch*> gDirectory;
 
 extern sai_acl_api_t *sai_acl_api;

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -535,6 +535,14 @@ namespace portsorch_test
             ASSERT_EQ((gPfcwdOrch<PfcWdDlrHandler, PfcWdDlrHandler>), nullptr);
             gPfcwdOrch<PfcWdDlrHandler, PfcWdDlrHandler> = new PfcWdSwOrch<PfcWdDlrHandler, PfcWdDlrHandler>(m_config_db.get(), pfc_wd_tables, portStatIds, queueStatIds, queueAttrIds, 100);
 
+            vector<string> mlag_tables = {
+                { CFG_MCLAG_TABLE_NAME },
+                { CFG_MCLAG_INTF_TABLE_NAME }
+            };
+
+            ASSERT_EQ(gMlagOrch, nullptr);
+            gMlagOrch = new MlagOrch(m_config_db.get(), mlag_tables);
+ 
         }
 
         virtual void TearDown() override
@@ -563,7 +571,8 @@ namespace portsorch_test
             gQosOrch = nullptr;
             delete gSwitchOrch;
             gSwitchOrch = nullptr;
-
+            delete gMlagOrch;
+            gMlagOrch = nullptr;
             // clear orchs saved in directory
             gDirectory.m_values.clear();
         }

--- a/tests/test_macsec.py
+++ b/tests/test_macsec.py
@@ -424,6 +424,7 @@ class TestMACsec(object):
         wpa.init_macsec_port(port_name)
         wpa.config_macsec_port(port_name, {"enable_protect": True})
         wpa.config_macsec_port(port_name, {"enable_encrypt": True})
+        wpa.config_macsec_port(port_name, {"send_sci": True})
         wpa.config_macsec_port(
             port_name,
             {


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Initialize the argument `sai_stat_capability_list_t` to a zero size when calling `sai_query_stats_capability` for the first time in `initCounterCapabilities`.

**Why I did it**

**How I verified it**

**Details if related**
